### PR TITLE
Statistics: fix a bug in `::toProto()` with empty Statistic, add test.

### DIFF
--- a/nighthawk/source/common/statistic_impl.cc
+++ b/nighthawk/source/common/statistic_impl.cc
@@ -16,8 +16,8 @@ std::string StatisticImpl::toString() const {
 nighthawk::client::Statistic StatisticImpl::toProto() {
   nighthawk::client::Statistic statistic;
   statistic.set_count(count());
-  statistic.mutable_mean()->set_nanos(std::round(mean()));
-  statistic.mutable_pstdev()->set_nanos(std::round(pstdev()));
+  statistic.mutable_mean()->set_nanos(count() == 0 ? 0 : std::round(mean()));
+  statistic.mutable_pstdev()->set_nanos(count() == 0 ? 0 : std::round(pstdev()));
   return statistic;
 }
 

--- a/nighthawk/test/statistic_test.cc
+++ b/nighthawk/test/statistic_test.cc
@@ -176,6 +176,15 @@ TYPED_TEST(TypedStatisticTest, ProtoOutput) {
   EXPECT_EQ(proto.pstdev().nanos(), std::round(a.pstdev()));
 }
 
+TYPED_TEST(TypedStatisticTest, ProtoOutputEmptyStats) {
+  TypeParam a;
+  const nighthawk::client::Statistic proto = a.toProto();
+
+  EXPECT_EQ(proto.count(), 0);
+  EXPECT_EQ(proto.mean().nanos(), 0);
+  EXPECT_EQ(proto.pstdev().nanos(), 0);
+}
+
 class StatisticTest : public testing::Test {};
 
 TEST(StatisticTest, HdrStatisticPercentilesProto) {


### PR DESCRIPTION
Attempting to serialize a `Statistic` with zero values added would
result in a vague complaint: ""JsonObjectWriter was not fully closed".

Some sleuthing pintpointed this to `std::nan` values returned by
`mean()` and `pstdev()`, which would then be passed to
`set_nanos()` in proto duration fields.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>