### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/cloudperf/utils.py
+++ b/cloudperf/utils.py
@@ -4,6 +4,11 @@ import os
 import random
 import string
 
+try:
+  xrange          # Python 2
+except NameError
+  xrange = range  # Python 3
+
 
 def CreateBooleanArgument(parser, argument_name, help_string,
                           **default_condition):


### PR DESCRIPTION
@htuch A bit-sized subset of #30

Signed-off-by: cclauss <cclauss@me.com>