### PR TITLE
print() function in database_helpers.py

### DIFF
--- a/cloudperf/database_helpers.py
+++ b/cloudperf/database_helpers.py
@@ -1,4 +1,5 @@
 """This file consists of database helper functions."""
+from __future__ import print_function
 
 import re
 import subprocess
@@ -87,7 +88,7 @@ def AuthorizeMachineAndConnectDB(db_instance_name, project, username, database,
                              "--instance", db_instance_name, "--password",
                              password], project=project,
                             service="sql", logfile=logfile)
-  print "DB Usernames and passwords are set."
+  print("DB Usernames and passwords are set.")
   connection = MySQLdb.connect(host=hostname, user=username,
                                passwd=password, db=database)
   return connection


### PR DESCRIPTION
@htuch A bit-sized subset of #30  Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Signed-off-by: cclauss <cclauss@me.com>