### PR TITLE
Nighthawk: ASAN/TSAN, Update Envoy, sync up misc changes 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+import %workspace%/nighthawk/envoy/.bazelrc
+build:asan --action_env="CC=clang"
+build:asan --action_env="CXX=clang++"
+
+build:tsan --action_env="CC=clang"
+build:tsan --action_env="CXX=clang++"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,22 @@ jobs:
       - run: ci/do_ci.sh coverage
       - store_artifacts:
           path: /root/project/generated
-          destination: /
+          destination: /      
+  asan:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh asan
+  tsan:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh tsan
+
 workflows:
   version: 2
   all:
@@ -51,3 +66,5 @@ workflows:
       - clang_tidy
 #      - test_with_valgrind
       - coverage
+      - asan
+      - tsan

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ bazel-*
 ._.DS_Store
 res.txt
 compile_commands.json
-.bazelrc
 .cache
 generated/
 .local
+.cmake
+.rnd
+bazel.output.txt
+measurements/

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -1,0 +1,1 @@
+# TODO(oschaaf): this is a stub. symlinking to envoy's copy fails here.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -37,7 +37,11 @@ function setup_clang_toolchain() {
     echo "$CC/$CXX toolchain configured"
 }
 
-# This overrides both ld and ld.gold with llvm's ld.lld.
+# TODO(oschaaf): This is quite the hack, we want to revisit this and back it out
+# once we figure out why bazel coverage isn't working as expected without doing
+# this. Once we do figure that out, this hack *could* be rewritten to assert that the linker
+# that gets used is the actual one we requested.
+# Overrides both ld and ld.gold with llvm's ld.lld.
 function override_linker_with_lld() {
     WORK_DIR=`mktemp -d -p "$DIR"`
     export PATH="$WORK_DIR:$PATH"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -23,12 +23,72 @@ function do_coverage() {
     ci/run_coverage.sh
 }
 
-CONCURRENCY=8
+function setup_gcc_toolchain() {
+    export CC=gcc
+    export CXX=g++
+    echo "$CC/$CXX toolchain configured"
+}
 
-# TODO(oschaaf): To avoid OOM kicking in, we throttle resources here. Revisit this later
-# to see how this was finally resolved in Envoy's code base. There is a TODO for when
-# when a later bazel version is deployed in CI here:
-# https://github.com/lizan/envoy/blob/2eb772ac7518c8fbf2a8c7acbc1bf89e548d9c86/ci/do_ci.sh#L86
+function setup_clang_toolchain() {
+    export PATH=/usr/lib/llvm-7/bin:$PATH
+    export CC=clang
+    export CXX=clang++
+    export ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-7/bin/llvm-symbolizer
+    echo "$CC/$CXX toolchain configured"
+}
+
+# This overrides both ld and ld.gold with llvm's ld.lld.
+function override_linker_with_lld() {
+    WORK_DIR=`mktemp -d -p "$DIR"`
+    export PATH="$WORK_DIR:$PATH"
+    ln -s "$(which ld.lld)" "$WORK_DIR/ld"
+    # We write a script to call ld.lld as 'ld' because it objects to being
+    # called `ld.gold` on some systems.
+    script="#!/bin/bash
+$WORK_DIR/ld \$@
+"
+    echo "$script" > "$WORK_DIR/ld.gold"
+    chmod +x "$WORK_DIR/ld.gold"
+    echo "lld linker override in place:"
+    # As a test, we output the version of ld.lld, which has some diagnostic value as well.
+    $WORK_DIR/ld.gold -v
+}
+
+function run_bazel() {
+    declare -r BAZEL_OUTPUT="${SRCDIR}"/bazel.output.txt
+    bazel $* | tee "${BAZEL_OUTPUT}"
+    declare BAZEL_STATUS="${PIPESTATUS[0]}"
+    if [ "${BAZEL_STATUS}" != "0" ]
+    then
+        declare -r FAILED_TEST_LOGS="$(grep "  /build.*test.log" "${BAZEL_OUTPUT}" | sed -e 's/  \/build.*\/testlogs\/\(.*\)/\1/')"
+        cd bazel-testlogs
+        for f in ${FAILED_TEST_LOGS}
+        do
+            echo "Failed test log ${f}"
+            cp --parents -f $f "${ENVOY_FAILED_TEST_LOGS}"
+        done
+        exit "${BAZEL_STATUS}"
+    fi
+}
+
+function do_asan() {
+    echo "bazel ASAN/UBSAN debug build with tests"
+    echo "Building and testing envoy tests..."
+    override_linker_with_lld
+    cd "${SRCDIR}"
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-asan //nighthawk/test:nighthawk_test
+}
+
+function do_tsan() {
+    echo "bazel TSAN debug build with tests"
+    echo "Building and testing envoy tests..."
+    override_linker_with_lld
+    cd "${SRCDIR}"
+    run_bazel test ${BAZEL_TEST_OPTIONS} -c dbg --config=clang-tsan //nighthawk/test:nighthawk_test
+}
+
+[ -z "${NUM_CPUS}" ] && NUM_CPUS=`grep -c ^processor /proc/cpuinfo`
+
 if [ -n "$CIRCLECI" ]; then
     # TODO(oschaaf): hack, this should be done in .circleci/config.yml
     git submodule update --init --recursive
@@ -36,23 +96,27 @@ if [ -n "$CIRCLECI" ]; then
         mv "${HOME:-/root}/.gitconfig" "${HOME:-/root}/.gitconfig_save"
         echo 1
     fi
-    export TEST_TMPDIR=/build/tmp
-    mkdir -p "$TEST_TMPDIR"
-    export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only"
+
+    NUM_CPUS=8
+    if [ "$1" == "coverage" ]; then
+        NUM_CPUS=6
+    fi
 fi
+
+export BAZEL_EXTRA_TEST_OPTIONS="--test_env=ENVOY_IP_TEST_VERSIONS=v4only ${BAZEL_EXTRA_TEST_OPTIONS}"
+export BAZEL_BUILD_OPTIONS=" \
+--verbose_failures ${BAZEL_OPTIONS} --action_env=HOME --action_env=PYTHONUSERBASE \
+--jobs=${NUM_CPUS} --show_task_finish --experimental_generate_json_trace_profile ${BAZEL_BUILD_EXTRA_OPTIONS}"
+export BAZEL_TEST_OPTIONS="${BAZEL_BUILD_OPTIONS} --test_env=HOME --test_env=PYTHONUSERBASE \
+--test_env=UBSAN_OPTIONS=print_stacktrace=1 \
+--cache_test_results=no --test_output=all ${BAZEL_EXTRA_TEST_OPTIONS}"
+[[ -z "${SRCDIR}" ]] && SRCDIR="${PWD}"
+
+setup_clang_toolchain
 
 if [ "$1" == "coverage" ]; then
-    export CC=gcc
-    export CXX=g++
-    CONCURRENCY=6
-else
-    export PATH=/usr/lib/llvm-7/bin:$PATH
-    export CC=clang
-    export CXX=clang++
+    setup_gcc_toolchain
 fi
-
-export BAZEL_BUILD_OPTIONS="${BAZEL_BUILD_OPTIONS} --jobs ${CONCURRENCY}"
-export BAZEL_TEST_OPTIONS="${BAZEL_TEST_OPTIONS} "${BAZEL_EXTRA_TEST_OPTIONS}" --jobs ${CONCURRENCY} --local_test_jobs=${CONCURRENCY}"
 
 case "$1" in
     build)
@@ -71,8 +135,14 @@ case "$1" in
     coverage)
         do_coverage
     ;;
+    asan)
+        do_asan
+    ;;
+    tsan)
+        do_tsan
+    ;;
     *)
-        echo "must be one of [build,test,clang_tidy,test_with_valgrind,coverage]"
+        echo "must be one of [build,test,clang_tidy,test_with_valgrind,coverage,asan,tsan]"
         exit 1
     ;;
 esac

--- a/nighthawk/.bazelrc
+++ b/nighthawk/.bazelrc
@@ -1,1 +1,0 @@
-import %workspace%/envoy/.bazelrc

--- a/nighthawk/bazel/get_workspace_status
+++ b/nighthawk/bazel/get_workspace_status
@@ -1,1 +1,0 @@
-../envoy/bazel/get_workspace_status

--- a/nighthawk/source/client/benchmark_client_impl.cc
+++ b/nighthawk/source/client/benchmark_client_impl.cc
@@ -51,6 +51,7 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(Envoy::Api::Api& api,
 }
 
 void BenchmarkClientHttpImpl::initialize(Envoy::Runtime::Loader& runtime) {
+  ASSERT(uri_.address().get() != nullptr);
   envoy::api::v2::Cluster cluster_config;
   envoy::api::v2::core::BindConfig bind_config;
 

--- a/nighthawk/source/client/options_impl.cc
+++ b/nighthawk/source/client/options_impl.cc
@@ -40,14 +40,14 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "and --connections values.Default : 1. ",
       false, "1", "string", cmd);
 
-  std::vector<std::string> log_levels = {"trace", "debug", "info", "warn", "error"};
+  std::vector<std::string> log_levels = {"trace", "debug", "info", "warn", "error", "critical"};
   TCLAP::ValuesConstraint<std::string> verbosities_allowed(log_levels);
 
   TCLAP::ValueArg<std::string> verbosity(
       "v", "verbosity",
       "Verbosity of the output. Possible values: [trace, debug, info, warn, error, critical]. The "
       "default level is 'info'.",
-      false, "info", &verbosities_allowed, cmd);
+      false, "warn", &verbosities_allowed, cmd);
 
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "

--- a/nighthawk/source/common/statistic_impl.cc
+++ b/nighthawk/source/common/statistic_impl.cc
@@ -44,11 +44,13 @@ void SimpleStatistic::addValue(int64_t value) {
 
 uint64_t SimpleStatistic::count() const { return count_; }
 
-double SimpleStatistic::mean() const { return count_ == 0 ? std::nan("") : sum_x_ / count_; }
+double SimpleStatistic::mean() const { return count() == 0 ? std::nan("") : sum_x_ / count_; }
 
-double SimpleStatistic::pvariance() const { return (sum_x2_ / count_) - (mean() * mean()); }
+double SimpleStatistic::pvariance() const {
+  return count() == 0 ? std::nan("") : (sum_x2_ / count_) - (mean() * mean());
+}
 
-double SimpleStatistic::pstdev() const { return sqrt(pvariance()); }
+double SimpleStatistic::pstdev() const { return count() == 0 ? std::nan("") : sqrt(pvariance()); }
 
 StatisticPtr SimpleStatistic::combine(const Statistic& statistic) const {
   const SimpleStatistic& a = *this;
@@ -76,9 +78,13 @@ uint64_t StreamingStatistic::count() const { return count_; }
 
 double StreamingStatistic::mean() const { return count_ == 0 ? std::nan("") : mean_; }
 
-double StreamingStatistic::pvariance() const { return accumulated_variance_ / count_; }
+double StreamingStatistic::pvariance() const {
+  return count() == 0 ? std::nan("") : accumulated_variance_ / count_;
+}
 
-double StreamingStatistic::pstdev() const { return sqrt(pvariance()); }
+double StreamingStatistic::pstdev() const {
+  return count() == 0 ? std::nan("") : sqrt(pvariance());
+}
 
 StatisticPtr StreamingStatistic::combine(const Statistic& statistic) const {
   const StreamingStatistic& a = *this;
@@ -146,9 +152,9 @@ void HdrStatistic::addValue(int64_t value) {
 }
 
 uint64_t HdrStatistic::count() const { return histogram_->total_count; }
-double HdrStatistic::mean() const { return hdr_mean(histogram_); }
+double HdrStatistic::mean() const { return count() == 0 ? std::nan("") : hdr_mean(histogram_); }
 double HdrStatistic::pvariance() const { return pstdev() * pstdev(); }
-double HdrStatistic::pstdev() const { return hdr_stddev(histogram_); }
+double HdrStatistic::pstdev() const { return count() == 0 ? std::nan("") : hdr_stddev(histogram_); }
 
 StatisticPtr HdrStatistic::combine(const Statistic& statistic) const {
   auto combined = std::make_unique<HdrStatistic>();

--- a/nighthawk/test/benchmark_http_client_test.cc
+++ b/nighthawk/test/benchmark_http_client_test.cc
@@ -294,8 +294,7 @@ TEST_P(BenchmarkClientHttpTest, H1ConnectionFailure) {
   EXPECT_EQ(1, getCounter("upstream_cx_total"));
   EXPECT_LE(1, getCounter("upstream_rq_pending_failure_eject"));
   EXPECT_EQ(1, getCounter("upstream_rq_pending_total"));
-  EXPECT_EQ(1, getCounter("upstream_rq_total"));
-  EXPECT_EQ(6, nonZeroValuedCounterCount());
+  EXPECT_EQ(5, nonZeroValuedCounterCount());
 }
 
 TEST_P(BenchmarkClientHttpTest, H1MultiConnectionFailure) {
@@ -309,8 +308,7 @@ TEST_P(BenchmarkClientHttpTest, H1MultiConnectionFailure) {
   EXPECT_EQ(10, getCounter("upstream_cx_total"));
   EXPECT_LE(10, getCounter("upstream_rq_pending_failure_eject"));
   EXPECT_EQ(10, getCounter("upstream_rq_pending_total"));
-  EXPECT_EQ(10, getCounter("upstream_rq_total"));
-  EXPECT_EQ(6, nonZeroValuedCounterCount());
+  EXPECT_EQ(5, nonZeroValuedCounterCount());
 }
 
 TEST_P(BenchmarkClientHttpTest, EnableLatencyMeasurement) {

--- a/nighthawk/test/utility_test.cc
+++ b/nighthawk/test/utility_test.cc
@@ -129,7 +129,7 @@ TEST_P(UtilityAddressResolutionTest, AddressResolutionBadAddresses) {
   EXPECT_THROW(testResolution("a..b", address_family), UriException);
 }
 
-TEST_P(UtilityAddressResolutionTest, resolveTwiceReturnsCached) {
+TEST_P(UtilityAddressResolutionTest, ResolveTwiceReturnsCached) {
   Envoy::Network::DnsLookupFamily address_family =
       GetParam() == Envoy::Network::Address::IpVersion::v6
           ? Envoy::Network::DnsLookupFamily::V6Only

--- a/nighthawk/test/utility_test.cc
+++ b/nighthawk/test/utility_test.cc
@@ -116,6 +116,7 @@ TEST_P(UtilityAddressResolutionTest, AddressResolution) {
     EXPECT_THROW(testResolution("127.0.0.1:80", address_family), UriException);
   }
 }
+
 TEST_P(UtilityAddressResolutionTest, AddressResolutionBadAddresses) {
   Envoy::Network::DnsLookupFamily address_family = Envoy::Network::DnsLookupFamily::Auto;
 
@@ -126,6 +127,20 @@ TEST_P(UtilityAddressResolutionTest, AddressResolutionBadAddresses) {
   EXPECT_THROW(testResolution(".", address_family), UriException);
   EXPECT_THROW(testResolution("..", address_family), UriException);
   EXPECT_THROW(testResolution("a..b", address_family), UriException);
+}
+
+TEST_P(UtilityAddressResolutionTest, resolveTwiceReturnsCached) {
+  Envoy::Network::DnsLookupFamily address_family =
+      GetParam() == Envoy::Network::Address::IpVersion::v6
+          ? Envoy::Network::DnsLookupFamily::V6Only
+          : Envoy::Network::DnsLookupFamily::V4Only;
+
+  Envoy::Api::ApiPtr api = Envoy::Api::createApiForTest();
+  auto dispatcher = api->allocateDispatcher();
+  auto u = Uri::Parse("localhost");
+
+  EXPECT_EQ(u.resolve(*dispatcher, address_family).get(),
+            u.resolve(*dispatcher, address_family).get());
 }
 
 // TODO(oschaaf): we probably want to move this out to another file.


### PR DESCRIPTION
- This adds ASAN/TSAN to CI testing
- Syncs a few small improvements from the NH branch
- Updates Envoy to the latest
- Envoy stopped incrementing upstream_rq_total for HTTP/1 conn pool
  when request is circuit broken. Fix test expectations.
