### PR TITLE
Nighthawk output improvements

### DIFF
--- a/ci/run_coverage.sh
+++ b/ci/run_coverage.sh
@@ -32,7 +32,7 @@ if [ "$VALIDATE_COVERAGE" == "true" ]
 then
     COVERAGE_VALUE=$(grep -Po '.*lines[.]*: \K(\d|\.)*' "${COVERAGE_SUMMARY}")
     # TODO(oschaaf): The target is 97.5%, so up this whenever possible in follow ups.
-    COVERAGE_THRESHOLD=94.4
+    COVERAGE_THRESHOLD=96.6
     COVERAGE_FAILED=$(echo "${COVERAGE_VALUE}<${COVERAGE_THRESHOLD}" | bc)
     
     echo "HTML coverage report is in ${COVERAGE_DIR}/coverage.html"

--- a/nighthawk/README.md
+++ b/nighthawk/README.md
@@ -6,7 +6,7 @@
 
 The nighthawk client supports HTTP/1.1 and HTTP/2 over HTTP and HTTPS.
 
-HTTPS certificates are not yet validated
+HTTPS certificates are not yet validated.
 
 ## Prerequisites
 
@@ -16,40 +16,46 @@ First, follow steps 1 and 2 over at [Quick start Bazel build for developers](htt
 
 ## Building and testing Nighthawk
 ```bash
-# build it. for best accuracy it is important to specify -c opt.
-bazel build -c opt //nighthawk:nighthawk_client
-
 # test it
 bazel test -c fastbuild //nighthawk/test:nighthawk_test
 ```
+# build it. for best accuracy it is important to specify -c opt.
+bazel build -c opt //nighthawk:nighthawk_client
 
 ## Using the Nighthawk client
 
 ```
-➜ bazel-bin/nighthawk_client --help
+➜ bazel-bin/nighthawk/nighthawk_client --help
 
-USAGE:
+USAGE: 
 
-   bazel-bin/nighthawk_client  [-v <trace|debug|info|warn|error>]
-                               [--concurrency <string>] [--h2] [--timeout
-                               <uint64_t>] [--duration <uint64_t>]
-                               [--connections <uint64_t>] [--rps
-                               <uint64_t>] [--] [--version] [-h] <uri
-                               format>
+   bazel-bin/nighthawk/nighthawk_client  [--output-format <human|yaml
+                                        |json>] [-v <trace|debug|info|warn
+                                        |error|critical>] [--concurrency
+                                        <string>] [--h2] [--timeout
+                                        <uint64_t>] [--duration <uint64_t>]
+                                        [--connections <uint64_t>] [--rps
+                                        <uint64_t>] [--] [--version] [-h]
+                                        <uri format>
 
 
-Where:
+Where: 
 
-   -v <trace|debug|info|warn|error|critical>,  --verbosity <trace|debug|info|warn
-      |error|critical>
+   --output-format <human|yaml|json>
+     Verbosity of the output. Possible values: [human, yaml, json]. The
+     default output format is 'human'.
+
+   -v <trace|debug|info|warn|error|critical>,  --verbosity <trace|debug
+      |info|warn|error|critical>
      Verbosity of the output. Possible values: [trace, debug, info, warn,
-     error, critical]. The default level is 'warn'.
+     error, critical]. The default output format is 'info'.
 
    --concurrency <string>
      The number of concurrent event loops that should be used. Specify
-     'auto' to let Nighthawk leverage all vCPUs that have affinity to the Nighthawk
-     process. Note that increasing this results in an effective load multiplier
-     combined with the configured --rps and --connections values. Default: 1.
+     'auto' to let Nighthawk leverage all vCPUs that have affinity to the
+     Nighthawk process.Note that increasing this results in an effective
+     load multiplier combined with the configured-- rps and --connections
+     values.Default : 1. 
 
    --h2
      Use HTTP/2
@@ -63,8 +69,8 @@ Where:
      The number of seconds that the test should run. Default: 5.
 
    --connections <uint64_t>
-     The number of connections per event loop that the test should maximally use. Default:
-     1.
+     The number of connections per event loop that the test should
+     maximally use. Default: 1.
 
    --rps <uint64_t>
      The target requests-per-second rate. Default: 5.
@@ -83,7 +89,7 @@ Where:
      in case of https no certificates are validated.
 
 
-   Nighthawk, a L7 HTTP protocol family benchmarking tool.
+   Nighthawk, a L7 HTTP protocol family benchmarking tool based on Envoy.
 ```
 
 ## Sample benchmark run
@@ -92,68 +98,66 @@ Where:
 # start the benchmark target (Envoy in this case) on core 3.
 $ taskset -c 3 /path/to/envoy --config-path nighthawk/tools/envoy.yaml
 
-# run a quick benchmark using cpu cores 0 and 1.
-$ taskset -c 0-1 bazel-bin/nighthawk/nighthawk_client --connections 20 --rps 20000 --duration 5 --concurrency auto -v info http://127.0.0.1:10000/
+# run a quick benchmark using cpu cores 4 and 5.
+$ taskset -c 4-5 bazel-bin/nighthawk/nighthawk_client --rps 1000 --concurrency auto http://127.0.0.1:10000/
 Nighthawk - A layer 7 protocol benchmarking tool.
-[23:11:09.078497][3431][I] [nighthawk/source/client/client.cc:69] Detected 2 (v)CPUs with affinity..
-[23:11:09.078521][3431][I] [nighthawk/source/client/client.cc:73] Starting 2 threads / event loops. Test duration: 5 seconds.
-[23:11:09.078524][3431][I] [nighthawk/source/client/client.cc:75] Global targets: 40 connections and 40000 calls per second.
-[23:11:09.078526][3431][I] [nighthawk/source/client/client.cc:79]    (Per-worker targets: 20 connections and 20000 calls per second)
-Merged statistics:
-benchmark_http_client.queue_to_connect: Count: 200205. Mean: 0.92 μs. pstdev: 0.79 μs.
-  Percentile          Value (usec)
-          50%          0.906
-          75%          0.928
-          90%          0.949
-          99%          1.009
-        99.9%          1.662
-       99.99%         48.649
-      99.999%         71.223
-         100%         72.327
 
-benchmark_http_client.request_to_response: Count: 200205. Mean: 35.35 μs. pstdev: 38.04 μs.
-  Percentile          Value (usec)
-          50%         32.745
-          75%         33.427
-          90%         34.077
-          99%         57.885
-        99.9%        514.143
-       99.99%        1526.65
-      99.999%        3703.81
-         100%        3737.86
+benchmark_http_client.queue_to_connect: 9997 samples, mean: 0.000010513s, pstdev: 0.000007883s
+Percentile  Count       Latency        
+0           1           0.000006549s   
+0.5         4999        0.000007325s   
+0.75        7498        0.000010387s   
+0.8         7998        0.000012010s   
+0.9         8998        0.000017883s   
+0.95        9498        0.000025680s   
+0.990625    9905        0.000047415s   
+0.999023    9988        0.000076479s   
+1           9997        0.000113999s   
 
-sequencer.blocking: Count: 149. Mean: 70.58 μs. pstdev: 68.95 μs.
-  Percentile          Value (usec)
-          50%         42.353
-          75%         92.499
-          90%        157.351
-          99%        309.935
-        99.9%        317.167
-       99.99%        317.167
-      99.999%        317.167
-         100%        317.167
+benchmark_http_client.request_to_response: 9997 samples, mean: 0.000156183s, pstdev: 0.000147691s
+Percentile  Count       Latency        
+0           1           0.000055659s   
+0.5         5003        0.000146655s   
+0.75        7500        0.000152631s   
+0.8         7998        0.000161455s   
+0.9         8998        0.000205247s   
+0.95        9498        0.000269951s   
+0.990625    9904        0.000495695s   
+0.999023    9988        0.000971967s   
+1           9997        0.008059903s   
 
-sequencer.callback: Count: 200205. Mean: 37.08 μs. pstdev: 38.32 μs.
-  Percentile          Value (usec)
-          50%         34.447
-          75%         35.123
-          90%         35.789
-          99%         60.209
-        99.9%        523.807
-       99.99%         1532.1
-      99.999%        3707.26
-         100%        3741.44
+sequencer.blocking: 42 samples, mean: 0.000755961s, pstdev: 0.001613017s
+Percentile  Count       Latency        
+0           1           0.000067199s   
+0.5         21          0.000117843s   
+0.75        32          0.000540191s   
+0.8         34          0.000544223s   
+0.9         38          0.000653183s   
+0.95        40          0.003944319s   
+1           42          0.006995967s   
+1           42          0.006995967s   
+1           42          0.006995967s   
 
+sequencer.callback: 9997 samples, mean: 0.000173003s, pstdev: 0.000153462s
+Percentile  Count       Latency        
+0           1           0.000066339s   
+0.5         4999        0.000157879s   
+0.75        7498        0.000164863s   
+0.8         7998        0.000179951s   
+0.9         8998        0.000234383s   
+0.95        9498        0.000314831s   
+0.990625    9904        0.000558047s   
+0.999023    9988        0.001160063s   
+1           9997        0.008074751s   
 
-Merged counters
-counter client.benchmark.http_2xx:200207
-counter client.upstream_cx_http1_total:40
-counter client.upstream_cx_rx_bytes_total:721345821
-counter client.upstream_cx_total:40
-counter client.upstream_cx_tx_bytes_total:12012420
-counter client.upstream_rq_pending_total:40
-counter client.upstream_rq_total:200207
-[23:11:14.175907][3431][I] [nighthawk/source/client/client.cc:213] Done. Wrote measurements/1553811074141331579.json.
+Counter                                 Value       Per second
+client.benchmark.http_2xx               9999        1999.80
+client.upstream_cx_http1_total          2           0.40
+client.upstream_cx_rx_bytes_total       36026397    7205279.40
+client.upstream_cx_total                2           0.40
+client.upstream_cx_tx_bytes_total       599940      119988.00
+client.upstream_rq_pending_total        2           0.40
+client.upstream_rq_total                9999        1999.80
 ```
 
 Nighthawk will create a directory called `measurements/` and log results in json format there.
@@ -175,8 +179,14 @@ The name of the file will be `<epoch.json>`, which contains:
 - Consider using `taskset` to isolate client and server. On machines with multiple physical CPUs there is a choice here.
   You can partition client and server on the same physical processor, or run each of them on a different physical CPU. Be aware of the latency effects of interconnects such as QPI.
 - Consider disabling hyper-threading.
-- Consider tuning the benchmarking system for low latency (manually, or with tuned).
-  - TODO(oschaaf): link resources.
+- Consider tuning the benchmarking system for low (network) latency. You can do that manually, or install [tuned](http://manpages.ubuntu.com/manpages/bionic/man8/tuned-adm.8.html) and run:
+
+| As this may change boot flags, take precautions, and familiarize yourself with the tool on systems that you don't mind breaking. For example, running this has been observed to mess up dual-boot systems! |
+| --- |
+
+```
+sudo tuned-adm profile network-latency
+```
 - When using Nighthawk with concurrency > 1 or multiple connections, workers may produce significantly different results. That can happen because of various reasons:
   - Server fairness. For example, connections may end up being serviced by the same server thread, or not.
   - One of the clients may be unlucky and structurally spend time waiting on requests from the other(s)

--- a/nighthawk/include/nighthawk/client/factories.h
+++ b/nighthawk/include/nighthawk/client/factories.h
@@ -12,6 +12,7 @@
 
 #include "nighthawk/client/benchmark_client.h"
 #include "nighthawk/client/options.h"
+#include "nighthawk/client/output_formatter.h"
 #include "nighthawk/common/platform_util.h"
 #include "nighthawk/common/sequencer.h"
 #include "nighthawk/common/statistic.h"
@@ -31,7 +32,8 @@ class SequencerFactory {
 public:
   virtual ~SequencerFactory() = default;
   virtual SequencerPtr create(Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
-                              Envoy::MonotonicTime start_time, BenchmarkClient& benchmark_client) const PURE;
+                              Envoy::MonotonicTime start_time,
+                              BenchmarkClient& benchmark_client) const PURE;
 };
 
 class StoreFactory {
@@ -44,6 +46,12 @@ class StatisticFactory {
 public:
   virtual ~StatisticFactory() = default;
   virtual StatisticPtr create() const PURE;
+};
+
+class OutputFormatterFactory {
+public:
+  virtual ~OutputFormatterFactory() = default;
+  virtual OutputFormatterPtr create() const PURE;
 };
 
 } // namespace Client

--- a/nighthawk/include/nighthawk/client/options.h
+++ b/nighthawk/include/nighthawk/client/options.h
@@ -27,6 +27,8 @@ public:
   virtual bool h2() const PURE;
   virtual std::string concurrency() const PURE;
   virtual std::string verbosity() const PURE;
+  virtual std::string output_format() const PURE;
+
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option
    * values.

--- a/nighthawk/include/nighthawk/client/options.h
+++ b/nighthawk/include/nighthawk/client/options.h
@@ -19,7 +19,7 @@ class Options {
 public:
   virtual ~Options() {}
 
-  virtual uint64_t requests_per_second() const PURE;
+  virtual uint64_t requestsPerSecond() const PURE;
   virtual uint64_t connections() const PURE;
   virtual std::chrono::seconds duration() const PURE;
   virtual std::chrono::seconds timeout() const PURE;
@@ -27,7 +27,7 @@ public:
   virtual bool h2() const PURE;
   virtual std::string concurrency() const PURE;
   virtual std::string verbosity() const PURE;
-  virtual std::string output_format() const PURE;
+  virtual std::string outputFormat() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/nighthawk/include/nighthawk/client/output_formatter.h
+++ b/nighthawk/include/nighthawk/client/output_formatter.h
@@ -14,7 +14,7 @@ namespace Client {
 class OutputFormatter {
 public:
   virtual ~OutputFormatter() = default;
-  virtual void addResult(const std::string name, const std::vector<StatisticPtr>& statistics,
+  virtual void addResult(absl::string_view name, const std::vector<StatisticPtr>& statistics,
                          const std::map<std::string, uint64_t>& counters) PURE;
   virtual nighthawk::client::Output toProto() const PURE;
   virtual std::string toString() const PURE;

--- a/nighthawk/include/nighthawk/client/output_formatter.h
+++ b/nighthawk/include/nighthawk/client/output_formatter.h
@@ -20,5 +20,7 @@ public:
   virtual std::string toString() const PURE;
 };
 
+typedef std::unique_ptr<OutputFormatter> OutputFormatterPtr;
+
 } // namespace Client
 } // namespace Nighthawk

--- a/nighthawk/include/nighthawk/client/output_formatter.h
+++ b/nighthawk/include/nighthawk/client/output_formatter.h
@@ -14,6 +14,9 @@ namespace Client {
 class OutputFormatter {
 public:
   virtual ~OutputFormatter() = default;
+  virtual void addResult(const std::string name, const std::vector<StatisticPtr>& statistics,
+                         const std::map<std::string, uint64_t>& counters) PURE;
+  virtual nighthawk::client::Output toProto() const PURE;
   virtual std::string toString() const PURE;
 };
 

--- a/nighthawk/source/client/client.cc
+++ b/nighthawk/source/client/client.cc
@@ -113,10 +113,8 @@ Main::mergeWorkerStatistics(const StatisticFactory& statistic_factory,
 std::map<std::string, uint64_t>
 Main::mergeWorkerCounters(const std::vector<ClientWorkerPtr>& workers) const {
   std::map<std::string, uint64_t> merged;
-  const Utility util;
-
   for (auto& w : workers) {
-    const auto counters = util.mapCountersFromStore(
+    const auto counters = Utility().mapCountersFromStore(
         w->store(), [](std::string, uint64_t value) { return value > 0; });
     for (auto counter : counters) {
       if (merged.count(counter.first) == 0) {
@@ -187,17 +185,44 @@ public:
     return workers_;
   }
 
-  bool runWorkers() {
+  std::vector<StatisticPtr> vectorizeStatisticPtrMap(const StatisticFactory& statistic_factory,
+                                                     const StatisticPtrMap& statistics) const {
+    std::vector<StatisticPtr> v;
+    for (auto statistic : statistics) {
+      auto new_statistic = statistic_factory.create()->combine(*(statistic.second));
+      new_statistic->setId(statistic.first);
+      v.push_back(std::move(new_statistic));
+    }
+    return v;
+  }
+
+  bool runWorkers(OutputFormatter& formatter) {
+    bool ok = true;
     Envoy::Runtime::RandomGeneratorImpl generator;
     Envoy::Runtime::ScopedLoaderSingleton loader(
         Envoy::Runtime::LoaderPtr{new Envoy::Runtime::LoaderImpl(generator, store(), tls())});
+
     for (auto& w : workers_) {
       w->start();
     }
-    bool ok = true;
     for (auto& w : workers_) {
       w->waitForCompletion();
       ok = ok && w->success();
+    }
+
+    if (workers_.size() > 1) {
+      int i = 0;
+      for (auto& worker : workers_) {
+        if (worker->success()) {
+          StatisticFactoryImpl statistic_factory(options_);
+          formatter.addResult(
+              fmt::format("worker_{}", i),
+              vectorizeStatisticPtrMap(statistic_factory, worker->statistics()),
+              Utility().mapCountersFromStore(
+                  worker->store(), [](std::string, uint64_t value) { return value > 0; }));
+        }
+        i++;
+      }
     }
     return ok;
   }
@@ -218,8 +243,7 @@ private:
   const Options& options_;
 };
 
-bool Main::runWorkers(ProcessContext& context, std::vector<StatisticPtr>& merged_statistics,
-                      std::map<std::string, uint64_t>& merged_counters) const {
+bool Main::runWorkers(ProcessContext& context, OutputFormatter& formatter) const {
   Uri uri = Uri::Parse(options_->uri());
   try {
     // TODO(oschaaf): DnsLookupFamily should be optionized.
@@ -228,28 +252,25 @@ bool Main::runWorkers(ProcessContext& context, std::vector<StatisticPtr>& merged
     return false;
   }
   const std::vector<ClientWorkerPtr>& workers = context.createWorkers(uri, determineConcurrency());
-  if (context.runWorkers()) {
+  if (context.runWorkers(formatter)) {
     StatisticFactoryImpl statistic_factory(*options_);
-    merged_statistics = mergeWorkerStatistics(statistic_factory, workers);
-    merged_counters = mergeWorkerCounters(workers);
+    formatter.addResult("global", mergeWorkerStatistics(statistic_factory, workers),
+                        mergeWorkerCounters(workers));
     return true;
   }
   return false;
 }
 
-void Main::writeOutput(ProcessContext& context, const std::vector<StatisticPtr>& merged_statistics,
-                       const std::map<std::string, uint64_t>& merged_counters) const {
-  ConsoleOutputFormatterImpl console_formatter(context.time_system(), *options_, merged_statistics,
-                                               merged_counters);
+void Main::writeOutput(Envoy::Event::TimeSystem& time_system,
+                       OutputFormatter& output_formatter) const {
   // TODO(oschaaf): output format, location, method, etc should be optionized.
-  std::cout << console_formatter.toString();
-  JsonOutputFormatterImpl json_formatter(context.time_system(), *options_, merged_statistics,
-                                         merged_counters);
+  std::cout << output_formatter.toString();
+  JsonOutputFormatterImpl json_formatter(output_formatter);
   // TODO(oschaaf): we ought to handle errors here instead of the release assert,
   RELEASE_ASSERT(mkdir("measurements", 0777) == 0 || errno == EEXIST,
                  "Failed to create output directory");
   std::ofstream stream;
-  const int64_t epoch_seconds = context.time_system().systemTime().time_since_epoch().count();
+  const int64_t epoch_seconds = time_system.systemTime().time_since_epoch().count();
   std::string filename = fmt::format("measurements/{}.json", epoch_seconds);
   stream.open(filename);
   stream << json_formatter.toString();
@@ -260,13 +281,10 @@ bool Main::run() {
   Envoy::Thread::MutexBasicLockable log_lock;
   auto logging_context = std::make_unique<Envoy::Logger::Context>(
       spdlog::level::from_str(options_->verbosity()), "[%T.%f][%t][%L] %v", log_lock);
-  std::vector<StatisticPtr> merged_statistics;
-  std::map<std::string, uint64_t> merged_counters;
   ProcessContext context(*options_);
-
-  std::cout << "Nighthawk - A layer 7 protocol benchmarking tool.\n";
-  if (runWorkers(context, merged_statistics, merged_counters)) {
-    writeOutput(context, merged_statistics, merged_counters);
+  ConsoleOutputFormatterImpl console_formatter(context.time_system(), *options_);
+  if (runWorkers(context, console_formatter)) {
+    writeOutput(context.time_system(), console_formatter);
     return true;
   }
   std::cerr << "An error occurred";

--- a/nighthawk/source/client/client.cc
+++ b/nighthawk/source/client/client.cc
@@ -72,11 +72,11 @@ uint32_t Main::determineConcurrency() const {
   ENVOY_LOG(info, "Starting {} threads / event loops. Test duration: {} seconds.", concurrency,
             options_->duration().count());
   ENVOY_LOG(info, "Global targets: {} connections and {} calls per second.",
-            options_->connections() * concurrency, options_->requests_per_second() * concurrency);
+            options_->connections() * concurrency, options_->requestsPerSecond() * concurrency);
 
   if (concurrency > 1) {
     ENVOY_LOG(info, "   (Per-worker targets: {} connections and {} calls per second)",
-              options_->connections(), options_->requests_per_second());
+              options_->connections(), options_->requestsPerSecond());
   }
 
   return concurrency;
@@ -172,7 +172,7 @@ public:
     // track-for-future issue.
     const auto first_worker_start = time_system().monotonicTime() + kMinimalWorkerDelay;
     const double inter_worker_delay_usec =
-        (1. / options_.requests_per_second()) * 1000000 / concurrency;
+        (1. / options_.requestsPerSecond()) * 1000000 / concurrency;
     int worker_number = 0;
     while (workers_.size() < concurrency) {
       const auto worker_delay = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -210,6 +210,8 @@ public:
       ok = ok && w->success();
     }
 
+    // We don't write per-worker results if we only have a single worker, because the global results
+    // will be precisely the same.
     if (workers_.size() > 1) {
       int i = 0;
       for (auto& worker : workers_) {

--- a/nighthawk/source/client/client.h
+++ b/nighthawk/source/client/client.h
@@ -8,6 +8,7 @@
 #include "nighthawk/client/client_worker.h"
 #include "nighthawk/client/factories.h"
 #include "nighthawk/client/options.h"
+#include "nighthawk/client/output_formatter.h"
 #include "nighthawk/common/statistic.h"
 
 namespace Nighthawk {
@@ -25,8 +26,8 @@ public:
 private:
   uint32_t determineConcurrency() const;
   void configureComponentLogLevels(spdlog::level::level_enum level);
-  bool runWorkers(ProcessContext& context, std::vector<StatisticPtr>& merged_statistics,
-                  std::map<std::string, uint64_t>& merged_counters) const;
+  bool runWorkers(ProcessContext& contex, OutputFormatter& output_formatter) const;
+
   std::vector<StatisticPtr>
   mergeWorkerStatistics(const StatisticFactory& statistic_factory,
                         const std::vector<ClientWorkerPtr>& workers) const;
@@ -34,8 +35,7 @@ private:
   std::map<std::string, uint64_t>
   mergeWorkerCounters(const std::vector<ClientWorkerPtr>& workers) const;
 
-  void writeOutput(ProcessContext& context, const std::vector<StatisticPtr>& merged_statistics,
-                   const std::map<std::string, uint64_t>& merged_counters) const;
+  void writeOutput(Envoy::Event::TimeSystem& time_system, OutputFormatter& output_formatter) const;
 
   OptionsPtr options_;
   std::unique_ptr<Envoy::Logger::Context> logging_context_;

--- a/nighthawk/source/client/client.h
+++ b/nighthawk/source/client/client.h
@@ -35,8 +35,6 @@ private:
   std::map<std::string, uint64_t>
   mergeWorkerCounters(const std::vector<ClientWorkerPtr>& workers) const;
 
-  void writeOutput(Envoy::Event::TimeSystem& time_system, OutputFormatter& output_formatter) const;
-
   OptionsPtr options_;
   std::unique_ptr<Envoy::Logger::Context> logging_context_;
 };

--- a/nighthawk/source/client/factories_impl.cc
+++ b/nighthawk/source/client/factories_impl.cc
@@ -40,7 +40,7 @@ SequencerPtr SequencerFactoryImpl::create(Envoy::TimeSource& time_source,
                                           BenchmarkClient& benchmark_client) const {
   StatisticFactoryImpl statistic_factory(options_);
   RateLimiterPtr rate_limiter =
-      std::make_unique<LinearRateLimiter>(time_source, Frequency(options_.requests_per_second()));
+      std::make_unique<LinearRateLimiter>(time_source, Frequency(options_.requestsPerSecond()));
   SequencerTarget sequencer_target = [&benchmark_client](std::function<void()> f) -> bool {
     return benchmark_client.tryStartOne(f);
   };
@@ -66,7 +66,7 @@ OutputFormatterFactoryImpl::OutputFormatterFactoryImpl(Envoy::TimeSource& time_s
     : OptionBasedFactoryImpl(options), time_source_(time_source) {}
 
 OutputFormatterPtr OutputFormatterFactoryImpl::create() const {
-  const std::string format = options_.output_format();
+  const std::string format = options_.outputFormat();
   if (format == "human") {
     return std::make_unique<Client::ConsoleOutputFormatterImpl>(time_source_, options_);
   } else if (format == "json") {

--- a/nighthawk/source/client/factories_impl.cc
+++ b/nighthawk/source/client/factories_impl.cc
@@ -3,6 +3,7 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "nighthawk/source/client/benchmark_client_impl.h"
+#include "nighthawk/source/client/output_formatter_impl.h"
 #include "nighthawk/source/common/platform_util_impl.h"
 #include "nighthawk/source/common/rate_limiter_impl.h"
 #include "nighthawk/source/common/sequencer_impl.h"
@@ -59,6 +60,22 @@ StatisticFactoryImpl::StatisticFactoryImpl(const Options& options)
     : OptionBasedFactoryImpl(options) {}
 
 StatisticPtr StatisticFactoryImpl::create() const { return std::make_unique<HdrStatistic>(); }
+
+OutputFormatterFactoryImpl::OutputFormatterFactoryImpl(Envoy::TimeSource& time_source,
+                                                       const Options& options)
+    : OptionBasedFactoryImpl(options), time_source_(time_source) {}
+
+OutputFormatterPtr OutputFormatterFactoryImpl::create() const {
+  const std::string format = options_.output_format();
+  if (format == "human") {
+    return std::make_unique<Client::ConsoleOutputFormatterImpl>(time_source_, options_);
+  } else if (format == "json") {
+    return std::make_unique<Client::JsonOutputFormatterImpl>(time_source_, options_);
+  } else if (format == "yaml") {
+    return std::make_unique<Client::YamlOutputFormatterImpl>(time_source_, options_);
+  }
+  NOT_REACHED_GCOVR_EXCL_LINE;
+}
 
 } // namespace Client
 } // namespace Nighthawk

--- a/nighthawk/source/client/factories_impl.h
+++ b/nighthawk/source/client/factories_impl.h
@@ -48,5 +48,14 @@ public:
   StatisticPtr create() const override;
 };
 
+class OutputFormatterFactoryImpl : public OptionBasedFactoryImpl, public OutputFormatterFactory {
+public:
+  OutputFormatterFactoryImpl(Envoy::TimeSource& time_source, const Options& options);
+  OutputFormatterPtr create() const override;
+
+private:
+  Envoy::TimeSource& time_source_;
+};
+
 } // namespace Client
 } // namespace Nighthawk

--- a/nighthawk/source/client/options.proto
+++ b/nighthawk/source/client/options.proto
@@ -21,6 +21,8 @@ message CommandLineOptions {
   string concurrency = 6;
   // See :option:`--verbosity` for details.
   string verbosity = 7;
+  // See :option:`--output-format` for details.
+  string output_format = 8;
   // See :option:`--uri` for details.
-  string uri = 8;
+  string uri = 9;
 }

--- a/nighthawk/source/client/options_impl.cc
+++ b/nighthawk/source/client/options_impl.cc
@@ -49,6 +49,15 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "default level is 'info'.",
       false, "warn", &verbosities_allowed, cmd);
 
+  std::vector<std::string> output_formats = {"human", "yaml", "json"};
+  TCLAP::ValuesConstraint<std::string> output_formats_allowed(log_levels);
+
+  TCLAP::ValueArg<std::string> output_format(
+      "", "output-format",
+      "Verbosity of the output. Possible values: [human, yaml, json]. The "
+      "default level is 'human'.",
+      false, "human", &output_formats_allowed, cmd);
+
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "
                                             "but in case of https no certificates are validated.",
@@ -79,6 +88,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   h2_ = h2.getValue();
   concurrency_ = concurrency.getValue();
   verbosity_ = verbosity.getValue();
+  output_format_ = output_format.getValue();
 
   // We cap on negative values. TCLAP accepts negative values which we will get here as very
   // large values. We just cap values to 2^63.

--- a/nighthawk/source/client/options_impl.cc
+++ b/nighthawk/source/client/options_impl.cc
@@ -50,7 +50,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       false, "warn", &verbosities_allowed, cmd);
 
   std::vector<std::string> output_formats = {"human", "yaml", "json"};
-  TCLAP::ValuesConstraint<std::string> output_formats_allowed(log_levels);
+  TCLAP::ValuesConstraint<std::string> output_formats_allowed(output_formats);
 
   TCLAP::ValueArg<std::string> output_format(
       "", "output-format",
@@ -135,12 +135,13 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
 
   command_line_options->set_connections(connections());
   command_line_options->mutable_duration()->set_seconds(duration().count());
-  command_line_options->set_requests_per_second(requests_per_second());
+  command_line_options->set_requests_per_second(requestsPerSecond());
   command_line_options->mutable_timeout()->set_seconds(timeout().count());
   command_line_options->set_h2(h2());
   command_line_options->set_uri(uri());
   command_line_options->set_concurrency(concurrency());
   command_line_options->set_verbosity(verbosity());
+  command_line_options->set_output_format(outputFormat());
 
   return command_line_options;
 }

--- a/nighthawk/source/client/options_impl.cc
+++ b/nighthawk/source/client/options_impl.cc
@@ -55,7 +55,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<std::string> output_format(
       "", "output-format",
       "Verbosity of the output. Possible values: [human, yaml, json]. The "
-      "default level is 'human'.",
+      "default output format is 'human'.",
       false, "human", &output_formats_allowed, cmd);
 
   TCLAP::UnlabeledValueArg<std::string> uri("uri",

--- a/nighthawk/source/client/options_impl.h
+++ b/nighthawk/source/client/options_impl.h
@@ -18,7 +18,7 @@ public:
 
   Client::CommandLineOptionsPtr toCommandLineOptions() const override;
 
-  uint64_t requests_per_second() const override { return requests_per_second_; }
+  uint64_t requestsPerSecond() const override { return requests_per_second_; }
   uint64_t connections() const override { return connections_; }
   std::chrono::seconds duration() const override { return std::chrono::seconds(duration_); }
   std::chrono::seconds timeout() const override { return std::chrono::seconds(timeout_); }
@@ -26,7 +26,7 @@ public:
   bool h2() const override { return h2_; }
   std::string concurrency() const override { return concurrency_; }
   std::string verbosity() const override { return verbosity_; };
-  std::string output_format() const override { return output_format_; };
+  std::string outputFormat() const override { return output_format_; };
 
 private:
   uint64_t requests_per_second_;

--- a/nighthawk/source/client/options_impl.h
+++ b/nighthawk/source/client/options_impl.h
@@ -26,6 +26,7 @@ public:
   bool h2() const override { return h2_; }
   std::string concurrency() const override { return concurrency_; }
   std::string verbosity() const override { return verbosity_; };
+  std::string output_format() const override { return output_format_; };
 
 private:
   uint64_t requests_per_second_;
@@ -36,6 +37,7 @@ private:
   bool h2_;
   std::string concurrency_;
   std::string verbosity_;
+  std::string output_format_;
 };
 
 } // namespace Client

--- a/nighthawk/source/client/output_formatter_impl.cc
+++ b/nighthawk/source/client/output_formatter_impl.cc
@@ -8,73 +8,102 @@
 namespace Nighthawk {
 namespace Client {
 
-OutputFormatterImpl::OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options,
-                                         const std::vector<StatisticPtr>& merged_statistics,
-                                         const std::map<std::string, uint64_t>& merged_counters)
-    : time_source_(time_source), options_(options), merged_statistics_(merged_statistics),
-      merged_counters_(merged_counters) {}
+OutputFormatterImpl::OutputFormatterImpl(const OutputFormatter& formatter)
+    : output_(formatter.toProto()) {}
 
-ConsoleOutputFormatterImpl::ConsoleOutputFormatterImpl(
-    Envoy::TimeSource& time_source, const Options& options,
-    const std::vector<StatisticPtr>& merged_statistics,
-    const std::map<std::string, uint64_t>& merged_counters)
-    : OutputFormatterImpl(time_source, options, merged_statistics, merged_counters) {}
-
-std::string ConsoleOutputFormatterImpl::toString() const {
-  std::stringstream s;
-
-  // TODO(oschaaf): echo non-default options to CLI output?
-  s << "Merged statistics:\n";
-  for (auto& statistic : merged_statistics_) {
-    if (statistic->count() > 0) {
-      s << fmt::format("{}: {}\n", statistic->id(), statistic->toString());
-    }
-  }
-  s << "\nMerged counters\n";
-  for (auto counter : merged_counters_) {
-    s << fmt::format("counter {}:{}\n", counter.first, counter.second);
-  }
-  return s.str();
+OutputFormatterImpl::OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options) {
+  output_.set_allocated_options(options.toCommandLineOptions().release());
+  *(output_.mutable_timestamp()) = Envoy::Protobuf::util::TimeUtil::NanosecondsToTimestamp(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          time_source.systemTime().time_since_epoch())
+          .count());
 }
 
-Envoy::ProtobufTypes::MessagePtr OutputFormatterImpl::toProto() const {
-  nighthawk::client::Output output;
-  output.set_allocated_options(options_.toCommandLineOptions().release());
-  *(output.mutable_timestamp()) = Envoy::Protobuf::util::TimeUtil::NanosecondsToTimestamp(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
-          time_source_.systemTime().time_since_epoch())
-          .count());
-  auto result = output.add_results();
-  result->set_name("global");
-  for (auto& statistic : merged_statistics_) {
+nighthawk::client::Output OutputFormatterImpl::toProto() const { return output_; }
+
+ConsoleOutputFormatterImpl::ConsoleOutputFormatterImpl(const OutputFormatter& formatter)
+    : OutputFormatterImpl(formatter) {}
+
+ConsoleOutputFormatterImpl::ConsoleOutputFormatterImpl(Envoy::TimeSource& time_source,
+                                                       const Options& options)
+    : OutputFormatterImpl(time_source, options) {}
+
+std::string ConsoleOutputFormatterImpl::toString() const {
+  std::stringstream ss;
+  const auto& output = toProto();
+  const double output_percentiles[] = {.0, .5, .75, .8, .9, .95, .99, .999, 1.};
+  ss << "Nighthawk - A layer 7 protocol benchmarking tool." << std::endl << std::endl;
+  for (const auto& result : output.results()) {
+    if (result.name() == "global") {
+      for (const auto& statistic : result.statistics()) {
+        if (statistic.count() == 0) {
+          continue;
+        }
+        ss << fmt::format("{}: {} samples, mean: {}, pstdev: {}", statistic.id(), statistic.count(),
+                          statistic.mean(), statistic.pstdev())
+           << std::endl;
+        ss << fmt::format("{:<{}}{:<{}}{:<{}}", "Percentile", 12, "Count", 12, "Latency", 15)
+           << std::endl;
+        for (const double p : output_percentiles) {
+          for (const auto& percentile : statistic.percentiles()) {
+            if (percentile.percentile() >= p) {
+              ss << fmt::format("{:<{}}{:<{}}{:<{}}", percentile.percentile(), 12,
+                                percentile.count(), 12, percentile.duration(), 15)
+                 << std::endl;
+              break;
+            }
+          }
+        }
+        ss << std::endl;
+      }
+      ss << fmt::format("{:<{}}{:<{}}{}", "Counter", 40, "Value", 12, "Per second") << std::endl;
+      for (const auto& counter : result.counters()) {
+        ss << fmt::format("{:<{}}{:<{}}{:.{}f}", counter.name(), 40, counter.value(), 12,
+                          counter.value() / (output.options().duration().seconds() * 1.0), 2)
+           << std::endl;
+      }
+      ss << std::endl;
+    }
+  }
+
+  return ss.str();
+}
+
+void OutputFormatterImpl::addResult(const std::string name,
+                                    const std::vector<StatisticPtr>& statistics,
+                                    const std::map<std::string, uint64_t>& counters) {
+  auto result = output_.add_results();
+  result->set_name(name);
+  for (auto& statistic : statistics) {
     *(result->add_statistics()) = statistic->toProto();
   }
-  for (auto counter : merged_counters_) {
+  for (auto counter : counters) {
     auto counters = result->add_counters();
     counters->set_name(counter.first);
     counters->set_value(counter.second);
   }
-  return std::make_unique<nighthawk::client::Output>(std::move(output));
 }
 
-JsonOutputFormatterImpl::JsonOutputFormatterImpl(
-    Envoy::TimeSource& time_source, const Options& options,
-    const std::vector<StatisticPtr>& merged_statistics,
-    const std::map<std::string, uint64_t>& merged_counters)
-    : OutputFormatterImpl(time_source, options, merged_statistics, merged_counters) {}
+JsonOutputFormatterImpl::JsonOutputFormatterImpl(const OutputFormatter& formatter)
+    : OutputFormatterImpl(formatter) {}
+
+JsonOutputFormatterImpl::JsonOutputFormatterImpl(Envoy::TimeSource& time_source,
+                                                 const Options& options)
+    : OutputFormatterImpl(time_source, options) {}
 
 std::string JsonOutputFormatterImpl::toString() const {
-  return Envoy::MessageUtil::getJsonStringFromMessage(*toProto(), true, true);
+  return Envoy::MessageUtil::getJsonStringFromMessage(toProto(), true, true);
 }
 
-YamlOutputFormatterImpl::YamlOutputFormatterImpl(
-    Envoy::TimeSource& time_source, const Options& options,
-    const std::vector<StatisticPtr>& merged_statistics,
-    const std::map<std::string, uint64_t>& merged_counters)
-    : OutputFormatterImpl(time_source, options, merged_statistics, merged_counters) {}
+YamlOutputFormatterImpl::YamlOutputFormatterImpl(const OutputFormatter& formatter)
+    : OutputFormatterImpl(formatter) {}
+
+YamlOutputFormatterImpl::YamlOutputFormatterImpl(Envoy::TimeSource& time_source,
+                                                 const Options& options)
+    : OutputFormatterImpl(time_source, options) {}
 
 std::string YamlOutputFormatterImpl::toString() const {
-  return Envoy::MessageUtil::getYamlStringFromMessage(*toProto(), true, true);
+  return Envoy::MessageUtil::getYamlStringFromMessage(toProto(), true, true);
 }
 
 } // namespace Client

--- a/nighthawk/source/client/output_formatter_impl.cc
+++ b/nighthawk/source/client/output_formatter_impl.cc
@@ -70,11 +70,11 @@ std::string ConsoleOutputFormatterImpl::toString() const {
   return ss.str();
 }
 
-void OutputFormatterImpl::addResult(const std::string name,
+void OutputFormatterImpl::addResult(absl::string_view name,
                                     const std::vector<StatisticPtr>& statistics,
                                     const std::map<std::string, uint64_t>& counters) {
   auto result = output_.add_results();
-  result->set_name(name);
+  result->set_name(name.data(), name.size());
   for (auto& statistic : statistics) {
     *(result->add_statistics()) = statistic->toProto();
   }

--- a/nighthawk/source/client/output_formatter_impl.cc
+++ b/nighthawk/source/client/output_formatter_impl.cc
@@ -8,9 +8,6 @@
 namespace Nighthawk {
 namespace Client {
 
-OutputFormatterImpl::OutputFormatterImpl(const OutputFormatter& formatter)
-    : output_(formatter.toProto()) {}
-
 OutputFormatterImpl::OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options) {
   *(output_.mutable_timestamp()) = Envoy::Protobuf::util::TimeUtil::NanosecondsToTimestamp(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -20,9 +17,6 @@ OutputFormatterImpl::OutputFormatterImpl(Envoy::TimeSource& time_source, const O
 }
 
 nighthawk::client::Output OutputFormatterImpl::toProto() const { return output_; }
-
-ConsoleOutputFormatterImpl::ConsoleOutputFormatterImpl(const OutputFormatter& formatter)
-    : OutputFormatterImpl(formatter) {}
 
 ConsoleOutputFormatterImpl::ConsoleOutputFormatterImpl(Envoy::TimeSource& time_source,
                                                        const Options& options)
@@ -85,9 +79,6 @@ void OutputFormatterImpl::addResult(absl::string_view name,
   }
 }
 
-JsonOutputFormatterImpl::JsonOutputFormatterImpl(const OutputFormatter& formatter)
-    : OutputFormatterImpl(formatter) {}
-
 JsonOutputFormatterImpl::JsonOutputFormatterImpl(Envoy::TimeSource& time_source,
                                                  const Options& options)
     : OutputFormatterImpl(time_source, options) {}
@@ -95,9 +86,6 @@ JsonOutputFormatterImpl::JsonOutputFormatterImpl(Envoy::TimeSource& time_source,
 std::string JsonOutputFormatterImpl::toString() const {
   return Envoy::MessageUtil::getJsonStringFromMessage(toProto(), true, true);
 }
-
-YamlOutputFormatterImpl::YamlOutputFormatterImpl(const OutputFormatter& formatter)
-    : OutputFormatterImpl(formatter) {}
 
 YamlOutputFormatterImpl::YamlOutputFormatterImpl(Envoy::TimeSource& time_source,
                                                  const Options& options)

--- a/nighthawk/source/client/output_formatter_impl.cc
+++ b/nighthawk/source/client/output_formatter_impl.cc
@@ -39,9 +39,11 @@ std::string ConsoleOutputFormatterImpl::toString() const {
            << std::endl;
 
         // The proto percentiles are ordered ascending. We write the first match to the stream.
+        double last_percentile = -1.;
         for (const double p : {.0, .5, .75, .8, .9, .95, .99, .999, 1.}) {
           for (const auto& percentile : statistic.percentiles()) {
-            if (percentile.percentile() >= p) {
+            if (percentile.percentile() >= p && last_percentile < percentile.percentile()) {
+              last_percentile = percentile.percentile();
               ss << fmt::format("{:<{}}{:<{}}{:<{}}", percentile.percentile(), 12,
                                 percentile.count(), 12, percentile.duration(), 15)
                  << std::endl;

--- a/nighthawk/source/client/output_formatter_impl.h
+++ b/nighthawk/source/client/output_formatter_impl.h
@@ -24,7 +24,7 @@ public:
   OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
   OutputFormatterImpl(const OutputFormatter& formatter);
 
-  void addResult(const std::string name, const std::vector<StatisticPtr>& statistics,
+  void addResult(absl::string_view name, const std::vector<StatisticPtr>& statistics,
                  const std::map<std::string, uint64_t>& counters) override;
 
   nighthawk::client::Output toProto() const override;

--- a/nighthawk/source/client/output_formatter_impl.h
+++ b/nighthawk/source/client/output_formatter_impl.h
@@ -16,13 +16,8 @@ public:
   /**
    * @param time_source Time source that will be used to generate a timestamp in the output.
    * @param options The options that led up to the output that will be computed by this instance.
-   * @param merged_statistics Vector of statistic instances which represent the global results
-   * (after merging results if multiple workers are involved).
-   * @param merged_counters Map of counters, keyed by id, representing the global result (after
-   * summing up the counters if multiple workers are involved).
    */
   OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
-  OutputFormatterImpl(const OutputFormatter& formatter);
 
   void addResult(absl::string_view name, const std::vector<StatisticPtr>& statistics,
                  const std::map<std::string, uint64_t>& counters) override;
@@ -36,22 +31,18 @@ private:
 class ConsoleOutputFormatterImpl : public OutputFormatterImpl {
 public:
   ConsoleOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
-  ConsoleOutputFormatterImpl(const OutputFormatter& formatter);
-
   std::string toString() const override;
 };
 
 class JsonOutputFormatterImpl : public OutputFormatterImpl {
 public:
   JsonOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
-  JsonOutputFormatterImpl(const OutputFormatter& formatter);
   std::string toString() const override;
 };
 
 class YamlOutputFormatterImpl : public OutputFormatterImpl {
 public:
   YamlOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
-  YamlOutputFormatterImpl(const OutputFormatter& formatter);
   std::string toString() const override;
 };
 

--- a/nighthawk/source/client/output_formatter_impl.h
+++ b/nighthawk/source/client/output_formatter_impl.h
@@ -21,40 +21,37 @@ public:
    * @param merged_counters Map of counters, keyed by id, representing the global result (after
    * summing up the counters if multiple workers are involved).
    */
-  OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options,
-                      const std::vector<StatisticPtr>& merged_statistics,
-                      const std::map<std::string, uint64_t>& merged_counters);
+  OutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
+  OutputFormatterImpl(const OutputFormatter& formatter);
 
-protected:
-  Envoy::ProtobufTypes::MessagePtr toProto() const;
+  void addResult(const std::string name, const std::vector<StatisticPtr>& statistics,
+                 const std::map<std::string, uint64_t>& counters) override;
 
-  Envoy::TimeSource& time_source_;
-  const Options& options_;
-  const std::vector<StatisticPtr>& merged_statistics_;
-  const std::map<std::string, uint64_t>& merged_counters_;
+  nighthawk::client::Output toProto() const override;
+
+private:
+  nighthawk::client::Output output_;
 };
 
 class ConsoleOutputFormatterImpl : public OutputFormatterImpl {
 public:
-  ConsoleOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options,
-                             const std::vector<StatisticPtr>& merged_statistics,
-                             const std::map<std::string, uint64_t>& merged_counters);
+  ConsoleOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
+  ConsoleOutputFormatterImpl(const OutputFormatter& formatter);
+
   std::string toString() const override;
 };
 
 class JsonOutputFormatterImpl : public OutputFormatterImpl {
 public:
-  JsonOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options,
-                          const std::vector<StatisticPtr>& merged_statistics,
-                          const std::map<std::string, uint64_t>& merged_counters);
+  JsonOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
+  JsonOutputFormatterImpl(const OutputFormatter& formatter);
   std::string toString() const override;
 };
 
 class YamlOutputFormatterImpl : public OutputFormatterImpl {
 public:
-  YamlOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options,
-                          const std::vector<StatisticPtr>& merged_statistics,
-                          const std::map<std::string, uint64_t>& merged_counters);
+  YamlOutputFormatterImpl(Envoy::TimeSource& time_source, const Options& options);
+  YamlOutputFormatterImpl(const OutputFormatter& formatter);
   std::string toString() const override;
 };
 

--- a/nighthawk/source/common/statistic_impl.cc
+++ b/nighthawk/source/common/statistic_impl.cc
@@ -1,3 +1,4 @@
+
 #include "nighthawk/source/common/statistic_impl.h"
 
 #include <cmath>

--- a/nighthawk/test/factories_test.cc
+++ b/nighthawk/test/factories_test.cc
@@ -46,7 +46,7 @@ TEST_F(FactoriesTest, CreateSequencer) {
 
   EXPECT_CALL(options_, timeout()).Times(1);
   EXPECT_CALL(options_, duration()).Times(1).WillOnce(testing::Return(1s));
-  EXPECT_CALL(options_, requests_per_second()).Times(1).WillOnce(testing::Return(1));
+  EXPECT_CALL(options_, requestsPerSecond()).Times(1).WillOnce(testing::Return(1));
   EXPECT_CALL(dispatcher_, createTimer_(_)).Times(2);
   Envoy::Event::SimulatedTimeSystem time_system;
   auto sequencer = factory.create(api_->timeSource(), dispatcher_, time_system.monotonicTime(),
@@ -70,7 +70,7 @@ public:
   void testOutputFormatter(const std::string type) {
     Envoy::RealTimeSource time_source;
     EXPECT_CALL(options_, toCommandLineOptions());
-    EXPECT_CALL(options_, output_format()).WillOnce(testing::Return(type));
+    EXPECT_CALL(options_, outputFormat()).WillOnce(testing::Return(type));
     OutputFormatterFactoryImpl factory(time_source, options_);
     EXPECT_NE(nullptr, factory.create().get());
   }

--- a/nighthawk/test/factories_test.cc
+++ b/nighthawk/test/factories_test.cc
@@ -64,5 +64,22 @@ TEST_F(FactoriesTest, CreateStatistic) {
   EXPECT_NE(nullptr, factory.create().get());
 }
 
+class OutputFormatterFactoryTest : public FactoriesTest,
+                                   public ::testing::WithParamInterface<const char*> {
+public:
+  void testOutputFormatter(const std::string type) {
+    Envoy::RealTimeSource time_source;
+    EXPECT_CALL(options_, toCommandLineOptions());
+    EXPECT_CALL(options_, output_format()).WillOnce(testing::Return(type));
+    OutputFormatterFactoryImpl factory(time_source, options_);
+    EXPECT_NE(nullptr, factory.create().get());
+  }
+};
+
+TEST_P(OutputFormatterFactoryTest, TestCreation) { testOutputFormatter(GetParam()); }
+
+INSTANTIATE_TEST_SUITE_P(OutputFormats, OutputFormatterFactoryTest,
+                         ::testing::ValuesIn({"human", "json", "yaml"}));
+
 } // namespace Client
 } // namespace Nighthawk

--- a/nighthawk/test/mocks.h
+++ b/nighthawk/test/mocks.h
@@ -63,7 +63,7 @@ public:
   MockOptions();
   ~MockOptions();
 
-  MOCK_CONST_METHOD0(requests_per_second, uint64_t());
+  MOCK_CONST_METHOD0(requestsPerSecond, uint64_t());
   MOCK_CONST_METHOD0(connections, uint64_t());
   MOCK_CONST_METHOD0(duration, std::chrono::seconds());
   MOCK_CONST_METHOD0(timeout, std::chrono::seconds());
@@ -71,7 +71,7 @@ public:
   MOCK_CONST_METHOD0(h2, bool());
   MOCK_CONST_METHOD0(concurrency, std::string());
   MOCK_CONST_METHOD0(verbosity, std::string());
-  MOCK_CONST_METHOD0(output_format, std::string());
+  MOCK_CONST_METHOD0(outputFormat, std::string());
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 

--- a/nighthawk/test/mocks.h
+++ b/nighthawk/test/mocks.h
@@ -71,6 +71,7 @@ public:
   MOCK_CONST_METHOD0(h2, bool());
   MOCK_CONST_METHOD0(concurrency, std::string());
   MOCK_CONST_METHOD0(verbosity, std::string());
+  MOCK_CONST_METHOD0(output_format, std::string());
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 

--- a/nighthawk/test/options_test.cc
+++ b/nighthawk/test/options_test.cc
@@ -43,27 +43,29 @@ TEST_F(OptionsImplTest, BogusInput) {
 TEST_F(OptionsImplTest, All) {
   std::unique_ptr<OptionsImpl> options =
       createOptionsImpl(fmt::format("{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
-                                    "--concurrency 8  --verbosity error {}",
+                                    "--concurrency 8 --verbosity error --output-format json {}",
                                     client_name_, good_test_uri_));
 
-  EXPECT_EQ(4, options->requests_per_second());
+  EXPECT_EQ(4, options->requestsPerSecond());
   EXPECT_EQ(5, options->connections());
   EXPECT_EQ(6s, options->duration());
   EXPECT_EQ(7s, options->timeout());
   EXPECT_EQ(true, options->h2());
   EXPECT_EQ("8", options->concurrency());
   EXPECT_EQ("error", options->verbosity());
+  EXPECT_EQ("json", options->outputFormat());
   EXPECT_EQ(good_test_uri_, options->uri());
 
   // Check that our conversion to CommandLineOptionsPtr makes sense.
   CommandLineOptionsPtr cmd = options->toCommandLineOptions();
-  EXPECT_EQ(cmd->requests_per_second(), options->requests_per_second());
+  EXPECT_EQ(cmd->requests_per_second(), options->requestsPerSecond());
   EXPECT_EQ(cmd->connections(), options->connections());
   EXPECT_EQ(cmd->duration().seconds(), options->duration().count());
   EXPECT_EQ(cmd->timeout().seconds(), options->timeout().count());
   EXPECT_EQ(cmd->h2(), options->h2());
   EXPECT_EQ(cmd->concurrency(), options->concurrency());
   EXPECT_EQ(cmd->verbosity(), options->verbosity());
+  EXPECT_EQ(cmd->output_format(), options->outputFormat());
   EXPECT_EQ(cmd->uri(), options->uri());
 }
 

--- a/nighthawk/test/output_formatter_test.cc
+++ b/nighthawk/test/output_formatter_test.cc
@@ -43,15 +43,16 @@ public:
 };
 
 TEST_F(OutputFormatterTest, CliFormatter) {
-  ConsoleOutputFormatterImpl formatter(time_system_, options_, statistics_, counters_);
+  ConsoleOutputFormatterImpl formatter(time_system_, options_);
+  formatter.addResult("global", statistics_, counters_);
   EXPECT_EQ(filesystem_.fileReadToEnd(TestEnvironment::runfilesPath(
                 "nighthawk/test/test_data/output_formatter.txt.gold")),
             formatter.toString());
 }
 
 TEST_F(OutputFormatterTest, JsonFormatter) {
-  JsonOutputFormatterImpl formatter(time_system_, options_, statistics_, counters_);
-
+  JsonOutputFormatterImpl formatter(time_system_, options_);
+  formatter.addResult("global", statistics_, counters_);
   EXPECT_CALL(options_, toCommandLineOptions)
       .WillOnce(Return(ByMove(std::make_unique<nighthawk::client::CommandLineOptions>())));
   EXPECT_EQ(filesystem_.fileReadToEnd(TestEnvironment::runfilesPath(
@@ -60,8 +61,8 @@ TEST_F(OutputFormatterTest, JsonFormatter) {
 }
 
 TEST_F(OutputFormatterTest, YamlFormatter) {
-  YamlOutputFormatterImpl formatter(time_system_, options_, statistics_, counters_);
-
+  YamlOutputFormatterImpl formatter(time_system_, options_);
+  formatter.addResult("global", statistics_, counters_);
   EXPECT_CALL(options_, toCommandLineOptions)
       .WillOnce(Return(ByMove(std::make_unique<nighthawk::client::CommandLineOptions>())));
   EXPECT_EQ(filesystem_.fileReadToEnd(TestEnvironment::runfilesPath(

--- a/nighthawk/test/test_data/output_formatter.json.gold
+++ b/nighthawk/test/test_data/output_formatter.json.gold
@@ -5,6 +5,7 @@
   "h2": false,
   "concurrency": "",
   "verbosity": "",
+  "output_format": "",
   "uri": "",
   "duration": "1s"
  },

--- a/nighthawk/test/test_data/output_formatter.json.gold
+++ b/nighthawk/test/test_data/output_formatter.json.gold
@@ -5,9 +5,68 @@
   "h2": false,
   "concurrency": "",
   "verbosity": "",
-  "uri": ""
+  "uri": "",
+  "duration": "1s"
  },
  "results": [
+  {
+   "name": "worker_0",
+   "statistics": [
+    {
+     "count": "3",
+     "id": "stat_id",
+     "percentiles": [],
+     "mean": "0.002s",
+     "pstdev": "0.000816497s"
+    },
+    {
+     "count": "0",
+     "id": "",
+     "percentiles": [],
+     "mean": "0s",
+     "pstdev": "0s"
+    }
+   ],
+   "counters": [
+    {
+     "name": "bar",
+     "value": "2"
+    },
+    {
+     "name": "foo",
+     "value": "1"
+    }
+   ]
+  },
+  {
+   "name": "worker_1",
+   "statistics": [
+    {
+     "count": "3",
+     "id": "stat_id",
+     "percentiles": [],
+     "mean": "0.002s",
+     "pstdev": "0.000816497s"
+    },
+    {
+     "count": "0",
+     "id": "",
+     "percentiles": [],
+     "mean": "0s",
+     "pstdev": "0s"
+    }
+   ],
+   "counters": [
+    {
+     "name": "bar",
+     "value": "2"
+    },
+    {
+     "name": "foo",
+     "value": "1"
+    }
+   ]
+  },
   {
    "name": "global",
    "statistics": [

--- a/nighthawk/test/test_data/output_formatter.txt.gold
+++ b/nighthawk/test/test_data/output_formatter.txt.gold
@@ -1,7 +1,9 @@
-Merged statistics:
-stat_id: Count: 3. Mean: 2000.00 μs. pstdev: 816.50 μs.
+Nighthawk - A layer 7 protocol benchmarking tool.
 
+stat_id: 3 samples, mean: 0.002s, pstdev: 0.000816497s
+Percentile  Count       Latency        
 
-Merged counters
-counter bar:2
-counter foo:1
+Counter                                 Value       Per second
+bar                                     2           2.00
+foo                                     1           1.00
+

--- a/nighthawk/test/test_data/output_formatter.yaml.gold
+++ b/nighthawk/test/test_data/output_formatter.yaml.gold
@@ -5,7 +5,46 @@ options:
   concurrency: ""
   verbosity: ""
   uri: ""
+  duration: 1s
 results:
+  - name: worker_0
+    statistics:
+      - count: 3
+        id: stat_id
+        percentiles:
+          []
+        mean: 0.002s
+        pstdev: 0.000816497s
+      - count: 0
+        id: ""
+        percentiles:
+          []
+        mean: 0s
+        pstdev: 0s
+    counters:
+      - name: bar
+        value: 2
+      - name: foo
+        value: 1
+  - name: worker_1
+    statistics:
+      - count: 3
+        id: stat_id
+        percentiles:
+          []
+        mean: 0.002s
+        pstdev: 0.000816497s
+      - count: 0
+        id: ""
+        percentiles:
+          []
+        mean: 0s
+        pstdev: 0s
+    counters:
+      - name: bar
+        value: 2
+      - name: foo
+        value: 1
   - name: global
     statistics:
       - count: 3

--- a/nighthawk/test/test_data/output_formatter.yaml.gold
+++ b/nighthawk/test/test_data/output_formatter.yaml.gold
@@ -4,6 +4,7 @@ options:
   h2: false
   concurrency: ""
   verbosity: ""
+  output_format: ""
   uri: ""
   duration: 1s
 results:


### PR DESCRIPTION
- Use the proto as a base to compute CLI output in `ConsoleOutputFormatterImpl` to ensure generic behavior across output formats (it used to do that from the native objects).
- Add --format=[human|json|yaml] option
- Write per-worker statistics in json/yaml output
- Clearer CLI output
- Factorize OutputFormatter creation
- Stop using std::err. 
- Stop writing files, we probably want to do that elsewhere.