### PR TITLE
 Nighthawk: add connection prefetching feature

### DIFF
--- a/nighthawk/README.md
+++ b/nighthawk/README.md
@@ -29,9 +29,10 @@ bazel build -c opt //nighthawk:nighthawk_client
 
 USAGE: 
 
-   bazel-bin/nighthawk/nighthawk_client  [--output-format <human|yaml
-                                        |json>] [-v <trace|debug|info|warn
-                                        |error|critical>] [--concurrency
+   bazel-bin/nighthawk/nighthawk_client  [--prefetch-connections]
+                                        [--output-format <human|yaml|json>]
+                                        [-v <trace|debug|info|warn|error
+                                        |critical>] [--concurrency
                                         <string>] [--h2] [--timeout
                                         <uint64_t>] [--duration <uint64_t>]
                                         [--connections <uint64_t>] [--rps
@@ -41,6 +42,9 @@ USAGE:
 
 Where: 
 
+   --prefetch-connections
+     Prefetch connections before benchmarking (HTTP/1 only).
+
    --output-format <human|yaml|json>
      Verbosity of the output. Possible values: [human, yaml, json]. The
      default output format is 'human'.
@@ -48,7 +52,7 @@ Where:
    -v <trace|debug|info|warn|error|critical>,  --verbosity <trace|debug
       |info|warn|error|critical>
      Verbosity of the output. Possible values: [trace, debug, info, warn,
-     error, critical]. The default output format is 'info'.
+     error, critical]. The default level is 'info'.
 
    --concurrency <string>
      The number of concurrent event loops that should be used. Specify
@@ -70,7 +74,7 @@ Where:
 
    --connections <uint64_t>
      The number of connections per event loop that the test should
-     maximally use. Default: 1.
+     maximally use. HTTP/1 only. Default: 1.
 
    --rps <uint64_t>
      The target requests-per-second rate. Default: 5.

--- a/nighthawk/include/nighthawk/client/benchmark_client.h
+++ b/nighthawk/include/nighthawk/client/benchmark_client.h
@@ -55,6 +55,8 @@ public:
    */
   virtual Envoy::Stats::Store& store() const PURE;
 
+  virtual void prefetchPoolConnections() PURE;
+
   /**
    * Determines if latency measurement is on.
    *

--- a/nighthawk/include/nighthawk/client/options.h
+++ b/nighthawk/include/nighthawk/client/options.h
@@ -28,6 +28,7 @@ public:
   virtual std::string concurrency() const PURE;
   virtual std::string verbosity() const PURE;
   virtual std::string outputFormat() const PURE;
+  virtual bool prefetchConnections() const PURE;
 
   /**
    * Converts an Options instance to an equivalent CommandLineOptions instance in terms of option

--- a/nighthawk/source/client/benchmark_client_impl.cc
+++ b/nighthawk/source/client/benchmark_client_impl.cc
@@ -33,11 +33,12 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(Envoy::Api::Api& api,
                                                  Envoy::Stats::Store& store,
                                                  StatisticPtr&& connect_statistic,
                                                  StatisticPtr&& response_statistic, const Uri& uri,
-                                                 bool use_h2)
+                                                 bool use_h2, bool prefetch_connections)
     : api_(api), dispatcher_(dispatcher), store_(store),
       scope_(store_.createScope("client.benchmark.")),
       connect_statistic_(std::move(connect_statistic)),
-      response_statistic_(std::move(response_statistic)), use_h2_(use_h2), uri_(uri),
+      response_statistic_(std::move(response_statistic)), use_h2_(use_h2),
+      prefetch_connections_(prefetch_connections), uri_(uri),
       benchmark_client_stats_({ALL_BENCHMARK_CLIENT_STATS(POOL_COUNTER(*scope_))}) {
   connect_statistic_->setId("benchmark_http_client.queue_to_connect");
   response_statistic_->setId("benchmark_http_client.request_to_response");
@@ -49,6 +50,32 @@ BenchmarkClientHttpImpl::BenchmarkClientHttpImpl(Envoy::Api::Api& api,
                                             ? Envoy::Http::Headers::get().SchemeValues.Https
                                             : Envoy::Http::Headers::get().SchemeValues.Http);
 }
+
+class H1Pool : public PrefetchablePool, public Envoy::Http::Http1::ProdConnPoolImpl {
+public:
+  H1Pool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
+         Envoy::Upstream::ResourcePriority priority,
+         const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options)
+      : Envoy::Http::Http1::ProdConnPoolImpl(dispatcher, host, priority, options) {}
+
+  void prefetchConnections() {
+    while (host_->cluster().resourceManager(priority_).connections().canCreate()) {
+      createNewConnection();
+    }
+  }
+};
+
+class H2Pool : public PrefetchablePool, public Envoy::Http::Http2::ProdConnPoolImpl {
+public:
+  H2Pool(Envoy::Event::Dispatcher& dispatcher, Envoy::Upstream::HostConstSharedPtr host,
+         Envoy::Upstream::ResourcePriority priority,
+         const Envoy::Network::ConnectionSocket::OptionsSharedPtr& options)
+      : Envoy::Http::Http2::ProdConnPoolImpl(dispatcher, host, priority, options) {}
+
+  void prefetchConnections() {
+    // No-op, this is a "pool" with a single connection.
+  }
+};
 
 void BenchmarkClientHttpImpl::initialize(Envoy::Runtime::Loader& runtime) {
   ASSERT(uri_.address().get() != nullptr);
@@ -124,11 +151,15 @@ void BenchmarkClientHttpImpl::initialize(Envoy::Runtime::Loader& runtime) {
   Envoy::Network::ConnectionSocket::OptionsSharedPtr options =
       std::make_shared<Envoy::Network::ConnectionSocket::Options>();
   if (use_h2_) {
-    pool_ = std::make_unique<Envoy::Http::Http2::ProdConnPoolImpl>(
-        dispatcher_, host, Envoy::Upstream::ResourcePriority::Default, options);
+    pool_ = std::make_unique<H2Pool>(dispatcher_, host, Envoy::Upstream::ResourcePriority::Default,
+                                     options);
   } else {
-    pool_ = std::make_unique<Envoy::Http::Http1::ProdConnPoolImpl>(
-        dispatcher_, host, Envoy::Upstream::ResourcePriority::Default, options);
+    pool_ = std::make_unique<H1Pool>(dispatcher_, host, Envoy::Upstream::ResourcePriority::Default,
+                                     options);
+  }
+
+  if (prefetch_connections_) {
+    prefetchPoolConnections();
   }
 }
 

--- a/nighthawk/source/client/benchmark_client_impl.h
+++ b/nighthawk/source/client/benchmark_client_impl.h
@@ -43,13 +43,20 @@ struct BenchmarkClientStats {
   ALL_BENCHMARK_CLIENT_STATS(GENERATE_COUNTER_STRUCT)
 };
 
+class PrefetchablePool {
+public:
+  virtual ~PrefetchablePool() = default;
+  virtual void prefetchConnections() PURE;
+};
+
 class BenchmarkClientHttpImpl : public BenchmarkClient,
                                 public StreamDecoderCompletionCallback,
                                 public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
 public:
   BenchmarkClientHttpImpl(Envoy::Api::Api& api, Envoy::Event::Dispatcher& dispatcher,
                           Envoy::Stats::Store& store, StatisticPtr&& connect_statistic,
-                          StatisticPtr&& response_statistic, const Uri& uri, bool use_h2);
+                          StatisticPtr&& response_statistic, const Uri& uri, bool use_h2,
+                          bool prefetch_connections);
 
   void setConnectionLimit(uint64_t connection_limit) { connection_limit_ = connection_limit; }
   void setConnectionTimeout(std::chrono::seconds timeout) { timeout_ = timeout; }
@@ -67,12 +74,15 @@ public:
   }
   bool tryStartOne(std::function<void()> caller_completion_callback) override;
   Envoy::Stats::Store& store() const override { return store_; }
-
   // StreamDecoderCompletionCallback
   void onComplete(bool success, const Envoy::Http::HeaderMap& headers) override;
   void onPoolFailure(Envoy::Http::ConnectionPool::PoolFailureReason reason) override;
 
 private:
+  void prefetchPoolConnections() override {
+    dynamic_cast<PrefetchablePool*>(pool_.get())->prefetchConnections();
+  }
+
   Envoy::Api::Api& api_;
   Envoy::Event::Dispatcher& dispatcher_;
   Envoy::Stats::Store& store_;
@@ -88,6 +98,7 @@ private:
   StatisticPtr connect_statistic_;
   StatisticPtr response_statistic_;
   const bool use_h2_;
+  const bool prefetch_connections_;
   const Uri uri_;
   std::chrono::seconds timeout_{5s};
   uint64_t connection_limit_{1};

--- a/nighthawk/source/client/client_worker_impl.cc
+++ b/nighthawk/source/client/client_worker_impl.cc
@@ -15,15 +15,10 @@ ClientWorkerImpl::ClientWorkerImpl(Envoy::Api::Api& api, Envoy::ThreadLocal::Ins
                                           *benchmark_client_)) {}
 
 void ClientWorkerImpl::simpleWarmup() {
-  ENVOY_LOG(debug, "> worker {}: warming up.", worker_number_);
-  // TODO(oschaaf): Maybe add BenchmarkClient::warmup() and call that here.
-  // Ideally we prefetch the requested amount of connections.
-  // Currently it is possible to use less connections then specified if
-  // completions are fast enough. While this may be an asset, it may also be annoying
-  // when comparing results to some other tools, which do open up the specified amount
-  // of connections.
+  ENVOY_LOG(debug, "> worker {}: warmup start.", worker_number_);
   benchmark_client_->tryStartOne([this] { dispatcher_->exit(); });
   dispatcher_->run(Envoy::Event::Dispatcher::RunType::Block);
+  ENVOY_LOG(debug, "> worker {}: warmup done.", worker_number_);
 }
 
 void ClientWorkerImpl::work() {

--- a/nighthawk/source/client/factories_impl.cc
+++ b/nighthawk/source/client/factories_impl.cc
@@ -23,9 +23,9 @@ BenchmarkClientPtr BenchmarkClientFactoryImpl::create(Envoy::Api::Api& api,
                                                       Envoy::Stats::Store& store,
                                                       const Uri uri) const {
   StatisticFactoryImpl statistic_factory(options_);
-  auto benchmark_client =
-      std::make_unique<BenchmarkClientHttpImpl>(api, dispatcher, store, statistic_factory.create(),
-                                                statistic_factory.create(), uri, options_.h2());
+  auto benchmark_client = std::make_unique<BenchmarkClientHttpImpl>(
+      api, dispatcher, store, statistic_factory.create(), statistic_factory.create(), uri,
+      options_.h2(), options_.prefetchConnections());
   benchmark_client->setConnectionTimeout(options_.timeout());
   benchmark_client->setConnectionLimit(options_.connections());
   return benchmark_client;

--- a/nighthawk/source/client/options.proto
+++ b/nighthawk/source/client/options.proto
@@ -23,6 +23,8 @@ message CommandLineOptions {
   string verbosity = 7;
   // See :option:`--output-format` for details.
   string output_format = 8;
+  // See :option:`--prefetch-connections` for details.
+  bool prefetch_connections = 9;
   // See :option:`--uri` for details.
-  string uri = 9;
+  string uri = 10;
 }

--- a/nighthawk/source/client/options_impl.cc
+++ b/nighthawk/source/client/options_impl.cc
@@ -19,7 +19,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   TCLAP::ValueArg<uint64_t> connections(
       "", "connections",
       "The number of connections per event loop that the test should maximally "
-      "use. Default: 1.",
+      "use. HTTP/1 only. Default: 1.",
       false, 1, "uint64_t", cmd);
   TCLAP::ValueArg<uint64_t> duration("", "duration",
                                      "The number of seconds that the test should run. Default: 5.",
@@ -58,6 +58,9 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
       "default output format is 'human'.",
       false, "human", &output_formats_allowed, cmd);
 
+  TCLAP::SwitchArg prefetch_connections(
+      "", "prefetch-connections", "Prefetch connections before benchmarking (HTTP/1 only).", cmd);
+
   TCLAP::UnlabeledValueArg<std::string> uri("uri",
                                             "uri to benchmark. http:// and https:// are supported, "
                                             "but in case of https no certificates are validated.",
@@ -89,6 +92,7 @@ OptionsImpl::OptionsImpl(int argc, const char* const* argv) {
   concurrency_ = concurrency.getValue();
   verbosity_ = verbosity.getValue();
   output_format_ = output_format.getValue();
+  prefetch_connections_ = prefetch_connections.getValue();
 
   // We cap on negative values. TCLAP accepts negative values which we will get here as very
   // large values. We just cap values to 2^63.
@@ -142,6 +146,7 @@ CommandLineOptionsPtr OptionsImpl::toCommandLineOptions() const {
   command_line_options->set_concurrency(concurrency());
   command_line_options->set_verbosity(verbosity());
   command_line_options->set_output_format(outputFormat());
+  command_line_options->set_prefetch_connections(prefetchConnections());
 
   return command_line_options;
 }

--- a/nighthawk/source/client/options_impl.h
+++ b/nighthawk/source/client/options_impl.h
@@ -27,6 +27,7 @@ public:
   std::string concurrency() const override { return concurrency_; }
   std::string verbosity() const override { return verbosity_; };
   std::string outputFormat() const override { return output_format_; };
+  bool prefetchConnections() const override { return prefetch_connections_; }
 
 private:
   uint64_t requests_per_second_;
@@ -38,6 +39,7 @@ private:
   std::string concurrency_;
   std::string verbosity_;
   std::string output_format_;
+  bool prefetch_connections_;
 };
 
 } // namespace Client

--- a/nighthawk/test/factories_test.cc
+++ b/nighthawk/test/factories_test.cc
@@ -34,6 +34,7 @@ TEST_F(FactoriesTest, CreateBenchmarkClient) {
   EXPECT_CALL(options_, timeout()).Times(1);
   EXPECT_CALL(options_, connections()).Times(1);
   EXPECT_CALL(options_, h2()).Times(1);
+  EXPECT_CALL(options_, prefetchConnections()).Times(1);
 
   auto benchmark_client =
       factory.create(*api_, dispatcher_, stats_store_, Uri::Parse("http://foo/"));

--- a/nighthawk/test/mocks.h
+++ b/nighthawk/test/mocks.h
@@ -72,6 +72,7 @@ public:
   MOCK_CONST_METHOD0(concurrency, std::string());
   MOCK_CONST_METHOD0(verbosity, std::string());
   MOCK_CONST_METHOD0(outputFormat, std::string());
+  MOCK_CONST_METHOD0(prefetchConnections, bool());
   MOCK_CONST_METHOD0(toCommandLineOptions, Client::CommandLineOptionsPtr());
 };
 
@@ -135,6 +136,7 @@ public:
   MOCK_CONST_METHOD0(statistics, StatisticPtrMap());
   MOCK_METHOD1(tryStartOne, bool(std::function<void()>));
   MOCK_CONST_METHOD0(store, Envoy::Stats::Store&());
+  MOCK_METHOD0(prefetchPoolConnections, void());
 
 protected:
   MOCK_CONST_METHOD0(measureLatencies, bool());

--- a/nighthawk/test/options_test.cc
+++ b/nighthawk/test/options_test.cc
@@ -41,10 +41,10 @@ TEST_F(OptionsImplTest, BogusInput) {
 }
 
 TEST_F(OptionsImplTest, All) {
-  std::unique_ptr<OptionsImpl> options =
-      createOptionsImpl(fmt::format("{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
-                                    "--concurrency 8 --verbosity error --output-format json {}",
-                                    client_name_, good_test_uri_));
+  std::unique_ptr<OptionsImpl> options = createOptionsImpl(fmt::format(
+      "{} --rps 4 --connections 5 --duration 6 --timeout 7 --h2 "
+      "--concurrency 8 --verbosity error --output-format json --prefetch-connections {}",
+      client_name_, good_test_uri_));
 
   EXPECT_EQ(4, options->requestsPerSecond());
   EXPECT_EQ(5, options->connections());
@@ -54,6 +54,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ("8", options->concurrency());
   EXPECT_EQ("error", options->verbosity());
   EXPECT_EQ("json", options->outputFormat());
+  EXPECT_EQ(true, options->prefetchConnections());
   EXPECT_EQ(good_test_uri_, options->uri());
 
   // Check that our conversion to CommandLineOptionsPtr makes sense.
@@ -66,6 +67,7 @@ TEST_F(OptionsImplTest, All) {
   EXPECT_EQ(cmd->concurrency(), options->concurrency());
   EXPECT_EQ(cmd->verbosity(), options->verbosity());
   EXPECT_EQ(cmd->output_format(), options->outputFormat());
+  EXPECT_EQ(cmd->prefetch_connections(), options->prefetchConnections());
   EXPECT_EQ(cmd->uri(), options->uri());
 }
 
@@ -110,6 +112,31 @@ TEST_F(OptionsImplTest, BadH2FlagThrows) {
   EXPECT_THROW_WITH_REGEX(
       createOptionsImpl(fmt::format("{} {} --h2 true", client_name_, good_test_uri_)),
       MalformedArgvException, "Couldn't find match for argument");
+}
+
+TEST_F(OptionsImplTest, H2Flag) {
+  EXPECT_FALSE(createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_))->h2());
+  EXPECT_TRUE(createOptionsImpl(fmt::format("{} {} --h2", client_name_, good_test_uri_))->h2());
+  EXPECT_THROW_WITH_REGEX(
+      createOptionsImpl(fmt::format("{} {} --h2 0", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
+  EXPECT_THROW_WITH_REGEX(
+      createOptionsImpl(fmt::format("{} {} --h2 true", client_name_, good_test_uri_)),
+      MalformedArgvException, "Couldn't find match for argument");
+}
+
+TEST_F(OptionsImplTest, PrefetchConnectionsFlag) {
+  EXPECT_FALSE(
+      createOptionsImpl(fmt::format("{} {}", client_name_, good_test_uri_))->prefetchConnections());
+  EXPECT_TRUE(
+      createOptionsImpl(fmt::format("{} {} --prefetch-connections", client_name_, good_test_uri_))
+          ->prefetchConnections());
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl(fmt::format("{} {} --prefetch-connections 0",
+                                                        client_name_, good_test_uri_)),
+                          MalformedArgvException, "Couldn't find match for argument");
+  EXPECT_THROW_WITH_REGEX(createOptionsImpl(fmt::format("{} {} --prefetch-connections true",
+                                                        client_name_, good_test_uri_)),
+                          MalformedArgvException, "Couldn't find match for argument");
 }
 
 TEST_F(OptionsImplTest, BadConcurrencyValuesThrow) {

--- a/nighthawk/test/test_data/output_formatter.json.gold
+++ b/nighthawk/test/test_data/output_formatter.json.gold
@@ -6,6 +6,7 @@
   "concurrency": "",
   "verbosity": "",
   "output_format": "",
+  "prefetch_connections": false,
   "uri": "",
   "duration": "1s"
  },

--- a/nighthawk/test/test_data/output_formatter.yaml.gold
+++ b/nighthawk/test/test_data/output_formatter.yaml.gold
@@ -5,6 +5,7 @@ options:
   concurrency: ""
   verbosity: ""
   output_format: ""
+  prefetch_connections: false
   uri: ""
   duration: 1s
 results:


### PR DESCRIPTION
Enabling connection prefetching will cause the client to open the
requested amount of connections to the benchmark target before performing
the actual benchmark.
