### PR TITLE
Fully dockerized flow skeleton

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -21,7 +21,7 @@ JSON Example:
     "envoyImage": "envoyproxy/envoy-dev:f61b096f6a2dd3a9c74b9a9369a6ea398dbe1f0f"
   },
   "environment": {
-    "testVersions": V4ONLY,
+    "testVersions": IPV_V4ONLY,
     "envoyPath": "envoy",
     "outputDir": "/home/ubuntu/nighthawk_output",
     "testDir": "/home/ubuntu/nighthawk_tests"
@@ -38,7 +38,7 @@ environment:
   envoyPath: 'envoy'
   outputDir: '/home/ubuntu/nighthawk_output'
   testDir: '/home/ubuntu/nighthawk_tests'
-  testVersions: V4ONLY
+  testVersions: IPV_V4ONLY
 images:
   reuseNhImages: true
   nighthawkBenchmarkImage: 'envoyproxy/nighthawk-benchmark-dev:latest'
@@ -63,7 +63,7 @@ bazel-bin/salvo --job ~/test_data/demo_jobcontrol.yaml
 ## Testing Salvo
 
 
-From the root package directory, run the do_ci.sh script with the "test" argument.  Since this installs packages packages, it will need to be run as root.
+From the root package directory, run the do_ci.sh script with the "test" argument. Since this installs packages packages, it will need to be run as root.
 ```bash
 bazel test //src/...
 ```

--- a/salvo/api/BUILD
+++ b/salvo/api/BUILD
@@ -1,6 +1,8 @@
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
 
-licenses(["notice"])  # Apache 2
+package(
+    default_visibility = ["//:__subpackages__"],
+)
 
 py_proto_library(
     name = "schema_proto",
@@ -11,5 +13,4 @@ py_proto_library(
         "image.proto",
         "source.proto",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/salvo/api/docker_volume.proto
+++ b/salvo/api/docker_volume.proto
@@ -2,21 +2,19 @@ syntax = "proto3";
 
 package salvo;
 
-// This message defines the properties for a given mount. It is used
-// to generate the dictionary specifying volumes for the Python Docker
-// SDK.  This message is not constructed by the user
-message VolumeProperties {
-  // Define whether the mount point is read-write or read-only
-  enum Mode {
-    RO = 0;
-    RW = 1;
-  }
+// The messages here are used internally by the framework to generate
+// the json structure specifying volumes for the Python Docker SDK.
+// These messages are not constructed by the user
 
-  // Specified the destination mount path in the benchmark container
+// This message defines the properties for a mount point.
+message VolumeProperties {
+
+  // Specify the destination mount path in the benchmark container
   string bind = 1;
 
-  // Specify whether the volume is read-write or read-only
-  Mode mode = 2;
+  // Specify whether the volume is read-write or read-only.  This field
+  // must be a string that is populated with 'rw' or 'ro' internally
+  string mode = 2;
 }
 
 // This message defines the volume structure consumed by the command

--- a/salvo/api/env.proto
+++ b/salvo/api/env.proto
@@ -6,10 +6,10 @@ package salvo;
 message EnvironmentVars {
   // Specify the IP version for tests
   enum TestIpVersion {
-    UNSPECIFIED = 0;
-    V4ONLY = 1;
-    V6ONLY = 2;
-    ALL = 3;
+    IPV_UNSPECIFIED = 0;
+    IPV_V4ONLY = 1;
+    IPV_V6ONLY = 2;
+    IPV_ALL = 3;
   }
 
   TestIpVersion test_version = 1;

--- a/salvo/api/env.proto
+++ b/salvo/api/env.proto
@@ -6,9 +6,10 @@ package salvo;
 message EnvironmentVars {
   // Specify the IP version for tests
   enum TestIpVersion {
-    V4ONLY = 0;
-    V6ONLY = 1;
-    ALL = 2;
+    UNSPECIFIED = 0;
+    V4ONLY = 1;
+    V6ONLY = 2;
+    ALL = 3;
   }
 
   TestIpVersion test_version = 1;

--- a/salvo/api/source.proto
+++ b/salvo/api/source.proto
@@ -7,8 +7,9 @@ message SourceRepository {
 
   // Specify whether this source location is Envoy or NightHawk
   enum SourceIdentity {
-    ENVOY = 0;
-    NIGHTHAWK = 1;
+    UNSPECIFIED = 0;
+    ENVOY = 1;
+    NIGHTHAWK = 2;
   }
 
   SourceIdentity identity = 1;

--- a/salvo/api/source.proto
+++ b/salvo/api/source.proto
@@ -7,9 +7,9 @@ message SourceRepository {
 
   // Specify whether this source location is Envoy or NightHawk
   enum SourceIdentity {
-    UNSPECIFIED = 0;
-    ENVOY = 1;
-    NIGHTHAWK = 2;
+    SRCID_UNSPECIFIED = 0;
+    SRCID_ENVOY = 1;
+    SRCID_NIGHTHAWK = 2;
   }
 
   SourceIdentity identity = 1;

--- a/salvo/salvo.py
+++ b/salvo/salvo.py
@@ -8,7 +8,6 @@ import sys
 
 from src.lib.job_control_loader import load_control_doc
 
-
 LOGFORMAT = "%(asctime)s: %(process)d [ %(levelname)-5s] [%(module)-5s] %(message)s"
 
 log = logging.getLogger()

--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -2,12 +2,15 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 licenses(["notice"])  # Apache 2
 
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
 py_library(
     name = "docker_image",
     data = [
         "docker_image.py",
     ],
-    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -15,7 +18,6 @@ py_library(
     data = [
         "docker_volume.py",
     ],
-    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -23,7 +25,13 @@ py_library(
     data = [
         "job_control_loader.py",
     ],
-    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "constants",
+    data = [
+        "constants.py",
+    ],
 )
 
 py_library(
@@ -49,6 +57,7 @@ py_test(
     srcs = ["test_job_control_loader.py"],
     srcs_version = "PY3",
     deps = [
+        ":constants",
         ":job_control",
         "//api:schema_proto",
     ],

--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -18,6 +18,9 @@ py_library(
     data = [
         "docker_volume.py",
     ],
+    deps = [
+        ":constants",
+    ],
 )
 
 py_library(
@@ -46,6 +49,7 @@ py_test(
     srcs = ["test_docker_image.py"],
     srcs_version = "PY3",
     deps = [
+        ":constants",
         ":docker_image",
         ":docker_volume",
         "//api:schema_proto",

--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -7,6 +7,7 @@ py_library(
     data = [
         "docker_image.py",
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -14,6 +15,7 @@ py_library(
     data = [
         "docker_volume.py",
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_library(

--- a/salvo/src/lib/benchmark/BUILD
+++ b/salvo/src/lib/benchmark/BUILD
@@ -1,0 +1,28 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+licenses(["notice"])  # Apache 2
+
+py_library(
+    name = "benchmark",
+    data = [
+        "base_benchmark.py",
+        "fully_dockerized_benchmark.py"
+    ],
+    deps = [
+        "//src/lib:docker_image",
+        "//src/lib:docker_volume",
+    ],
+    visibility = [ "//visibility:public" ]
+)
+
+py_test(
+  name = "test_fully_dockerized_benchmark",
+  srcs = [ "test_fully_dockerized_benchmark.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      "//src/lib:docker_image",
+      ":benchmark"
+  ],
+)
+

--- a/salvo/src/lib/benchmark/BUILD
+++ b/salvo/src/lib/benchmark/BUILD
@@ -2,6 +2,10 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 licenses(["notice"])  # Apache 2
 
+package(
+    default_visibility = ["//:__subpackages__"],
+)
+
 py_library(
     name = "benchmark",
     data = [
@@ -12,7 +16,6 @@ py_library(
         "//src/lib:docker_image",
         "//src/lib:docker_volume",
     ],
-    visibility = [ "//visibility:public" ]
 )
 
 py_test(

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -22,6 +22,7 @@ def get_docker_volumes(output_dir, test_dir=''):
   """
   return docker_volume.generate_volume_config(output_dir, test_dir)
 
+
 class BaseBenchmark(object):
   """Base Benchmark class with common functions for all invocations."""
 
@@ -87,4 +88,3 @@ class BaseBenchmark(object):
     Set the Envoy IP test versions and any other environment variables needed by the test
     """
     pass
-

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -43,27 +43,26 @@ class BaseBenchmark(object):
 
   def get_source(self):
     """
-    Return the source object from the control object
+    Return the source object defining locations from where either NightHawk or Envoy
+    can be built
     """
     pass
 
   def run_image(self, image_name, **kwargs):
     """
-    Run the specified docker image
+    Run the specified docker image witht he supplied keyword arguments
     """
     pass
 
   def pull_images(self):
     """
-    Retrieve all images defined in the control object.  The validation
-    logic should be run before this method.  The images object should be
-    populated with non-zero length strings.
+    Retrieve the NightHawk and Envoy images defined in the control object. 
     """
     pass
 
   def set_environment_vars(self):
     """
-    Set the Envoy IP test versions and any other variables controlling the test
+    Set the Envoy IP test versions and any other environment variables needed by the test
     """
     pass
 

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -11,57 +11,79 @@ import src.lib.docker_volume as docker_volume
 log = logging.getLogger(__name__)
 
 
-def get_docker_volumes(output_dir, test_dir=None):
-  """
+def get_docker_volumes(output_dir, test_dir=''):
+  """Build the volume structure needed to run a container.
+
   Build the json specifying the volume configuration needed for running the container
+
+  Args:
+      output_dir: The directory containing the artifacts of the benchmark
+      test_dir: If specified, points to the location of user supplied tests
   """
   return docker_volume.generate_volume_config(output_dir, test_dir)
 
 class BaseBenchmark(object):
-  """
-  Base Benchmark class with common functions for all invocations
-  """
+  """Base Benchmark class with common functions for all invocations."""
 
-  def __init__(self, job_control, benchmark_name, **kwargs):
-    """
-    Initialize the Base Benchmark class.
+  def __init__(self, job_control, benchmark_name):
+    """Initialize the Base Benchmark class.
+
+    Args:
+        job_control: The protobuf object containing the parameters and locations
+          of benchmark artifacts
+        benchmark_name: The name of the benchmark to execute
     """
     pass
 
   def is_remote(self):
-    """
-    Return a boolean indicating whether the test is to
-    be executed locally or remotely
+    """Return a boolean indicating whether the test is to be executed
+       locally or remotely.
+
+    Returns:
+        Whether or not the benchmark runs locally or in a remote service
     """
     pass
 
   def get_images(self):
-    """
-    Return the images object from the control object
+    """Return the images object from the control object.
+
+    Returns:
+        The images objects specified in the control object
     """
     pass
 
   def get_source(self):
-    """
-    Return the source object defining locations from where either NightHawk or Envoy
-    can be built
+    """Return the source object defining locations from where
+       NightHawk or Envoy can be built.
+
+    Returns:
+        The source objects specified in the control object
     """
     pass
 
   def run_image(self, image_name, **kwargs):
-    """
-    Run the specified docker image witht he supplied keyword arguments
+    """Run the specified docker image with the supplied keyword arguments.
+
+    Args:
+        image_name: The docker image to be executed
+        kwargs: Additional (optional) arguments passed to the docker
+          image for execution
+
+    Returns:
+        The output from executing the specified container
     """
     pass
 
   def pull_images(self):
-    """
+    """Retrieve all images necessary for the benchmark.
+
     Retrieve the NightHawk and Envoy images defined in the control object. 
     """
     pass
 
   def set_environment_vars(self):
-    """
+    """Build the environment variable map used to launch an image.
+
     Set the Envoy IP test versions and any other environment variables needed by the test
     """
     pass

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -19,6 +19,8 @@ def get_docker_volumes(output_dir, test_dir=''):
   Args:
       output_dir: The directory containing the artifacts of the benchmark
       test_dir: If specified, points to the location of user supplied tests
+      If the test_dir is not specified, the volume map will not include an
+      entry for the external test directory
   """
   return docker_volume.generate_volume_config(output_dir, test_dir)
 

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -9,9 +9,6 @@ import src.lib.docker_image as docker_image
 import src.lib.docker_volume as docker_volume
 
 log = logging.getLogger(__name__)
-"""
-Base Benchmark class with common functions for all invocations
-"""
 
 
 def get_docker_volumes(output_dir, test_dir=None):
@@ -21,8 +18,11 @@ def get_docker_volumes(output_dir, test_dir=None):
   return docker_volume.generate_volume_config(output_dir, test_dir)
 
 class BaseBenchmark(object):
+  """
+  Base Benchmark class with common functions for all invocations
+  """
 
-  def __init__(self, **kwargs):
+  def __init__(self, job_control, benchmark_name, **kwargs):
     """
     Initialize the Base Benchmark class.
     """

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -1,0 +1,69 @@
+"""
+Base Benchmark object module that contains
+options common to all execution methods
+"""
+import os
+import logging
+
+import src.lib.docker_image as docker_image
+import src.lib.docker_volume as docker_volume
+
+log = logging.getLogger(__name__)
+"""
+Base Benchmark class with common functions for all invocations
+"""
+
+
+def get_docker_volumes(output_dir, test_dir=None):
+  """
+  Build the json specifying the volume configuration needed for running the container
+  """
+  return docker_volume.generate_volume_config(output_dir, test_dir)
+
+class BaseBenchmark(object):
+
+  def __init__(self, **kwargs):
+    """
+    Initialize the Base Benchmark class.
+    """
+    pass
+
+  def is_remote(self):
+    """
+    Return a boolean indicating whether the test is to
+    be executed locally or remotely
+    """
+    pass
+
+  def get_images(self):
+    """
+    Return the images object from the control object
+    """
+    pass
+
+  def get_source(self):
+    """
+    Return the source object from the control object
+    """
+    pass
+
+  def run_image(self, image_name, **kwargs):
+    """
+    Run the specified docker image
+    """
+    pass
+
+  def pull_images(self):
+    """
+    Retrieve all images defined in the control object.  The validation
+    logic should be run before this method.  The images object should be
+    populated with non-zero length strings.
+    """
+    pass
+
+  def set_environment_vars(self):
+    """
+    Set the Envoy IP test versions and any other variables controlling the test
+    """
+    pass
+

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -14,17 +14,17 @@ log = logging.getLogger(__name__)
 
 class Benchmark(BaseBenchmark):
 
-  def __init__(self, **kwargs):
-    super(Benchmark, self).__init__(**kwargs)
+  def __init__(self, job_control, benchmark_name, **kwargs):
+    super(Benchmark, self).__init__(job_control, benchmark_name, **kwargs)
 
-  def validate(self):
+  def __validate(self):
     """
     Validate that all data required for running the dockerized
     benchmark is defined and or accessible
     """
     pass
 
-  def _verify_sources(self, images):
+  def __verify_sources(self, images):
     """
     Validate that sources are available from which we can build a missing image
     """
@@ -34,4 +34,4 @@ class Benchmark(BaseBenchmark):
     """
     Prepare input artifacts and run the benchmark
     """
-    pass
+    self.__validate()

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -1,0 +1,37 @@
+"""
+This module contains the methods to perform a nighthawk benchmark using
+containers for the scripts, nighthawk binaries, and envoy
+
+https://github.com/envoyproxy/nighthawk/blob/master/benchmarks/README.md
+"""
+
+import logging
+
+from src.lib.benchmark.base_benchmark import BaseBenchmark
+
+log = logging.getLogger(__name__)
+
+
+class Benchmark(BaseBenchmark):
+
+  def __init__(self, **kwargs):
+    super(Benchmark, self).__init__(**kwargs)
+
+  def validate(self):
+    """
+    Validate that all data required for running the scavenging
+    benchmark is defined and or accessible
+    """
+    pass
+
+  def _verify_sources(self, images):
+    """
+    Validate that sources are defined from which we can build a missing image
+    """
+    pass
+
+  def execute_benchmark(self):
+    """
+    Prepare input artifacts and run the benchmark
+    """
+    pass

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -17,14 +17,14 @@ class Benchmark(BaseBenchmark):
   def __init__(self, job_control, benchmark_name, **kwargs):
     super(Benchmark, self).__init__(job_control, benchmark_name, **kwargs)
 
-  def __validate(self):
+  def _validate(self):
     """
     Validate that all data required for running the dockerized
     benchmark is defined and or accessible
     """
     pass
 
-  def __verify_sources(self, images):
+  def _verify_sources(self, images):
     """
     Validate that sources are available from which we can build a missing image
     """
@@ -34,4 +34,4 @@ class Benchmark(BaseBenchmark):
     """
     Prepare input artifacts and run the benchmark
     """
-    self.__validate()
+    self._validate()

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -19,14 +19,14 @@ class Benchmark(BaseBenchmark):
 
   def validate(self):
     """
-    Validate that all data required for running the scavenging
+    Validate that all data required for running the dockerized
     benchmark is defined and or accessible
     """
     pass
 
   def _verify_sources(self, images):
     """
-    Validate that sources are defined from which we can build a missing image
+    Validate that sources are available from which we can build a missing image
     """
     pass
 

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -14,24 +14,30 @@ log = logging.getLogger(__name__)
 
 class Benchmark(BaseBenchmark):
 
-  def __init__(self, job_control, benchmark_name, **kwargs):
-    super(Benchmark, self).__init__(job_control, benchmark_name, **kwargs)
+  def __init__(self, job_control, benchmark_name):
+    """Initialize the benchmark class."""
+    super(Benchmark, self).__init__(job_control, benchmark_name)
 
   def _validate(self):
-    """
-    Validate that all data required for running the dockerized
-    benchmark is defined and or accessible
+    """Validate that all data required for running a benchmark exist.
+
+    Returns:
+        None
     """
     pass
 
   def _verify_sources(self, images):
-    """
-    Validate that sources are available from which we can build a missing image
+    """Validate that sources are available to build a missing image.
+
+    Returns:
+        None
     """
     pass
 
   def execute_benchmark(self):
-    """
-    Prepare input artifacts and run the benchmark
+    """Prepare input artifacts and run the benchmark.
+
+    Returns:
+        None
     """
     self._validate()

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -22,6 +22,7 @@ def test_no_envoy_image_no_sources():
   """
   pass
 
+
 def test_source_to_build_envoy():
   """Validate we can build images from source.
 
@@ -29,6 +30,7 @@ def test_source_to_build_envoy():
   We do not expect the validation logic to throw an exception
   """
   pass
+
 
 def test_no_source_to_build_envoy():
   """Validate that we fail to build images without sources.
@@ -38,6 +40,7 @@ def test_no_source_to_build_envoy():
   """
   pass
 
+
 def test_no_source_to_build_nh():
   """Validate that we fail to build nighthawk without sources.
 
@@ -46,6 +49,7 @@ def test_no_source_to_build_nh():
   """
   pass
 
+
 def test_no_source_to_build_nh2():
   """Validate that we fail to build nighthawk without sources.
 
@@ -53,6 +57,7 @@ def test_no_source_to_build_nh2():
   binary image. We expect the validation logic to throw an exception
   """
   pass
+
 
 if __name__ == '__main__':
   raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Test the fully dockerized benchmark class
+"""
+
+import site
+import pytest
+
+from api.control_pb2 import JobControl
+from src.lib.benchmark.fully_dockerized_benchmark import Benchmark
+
+
+def test_images_only_config():
+  """
+  Test benchmark validation logic
+  """
+  pass
+
+
+def test_no_envoy_image_no_sources():
+  """
+  Test benchmark validation logic.  No Envoy image is specified, we
+  expect the validation logic to throw an exception since no sources are present
+  """
+  pass
+
+def test_source_to_build_envoy():
+  """
+  Validate that sources are defined that enable us to build the Envoy image
+  We do not expect the validation logic to throw an exception
+  """
+  pass
+
+def test_no_source_to_build_envoy():
+  """
+  Validate that no sources are present that enable us to build the missing Envoy image
+  We expect the validation logic to throw an exception
+  """
+  pass
+
+def test_no_source_to_build_nh():
+  """
+  Validate that no sources are defined that enable us to build the missing NightHawk
+  benchmark image
+  We expect the validation logic to throw an exception
+  """
+  pass
+
+def test_no_source_to_build_nh2():
+  """
+  Validate that no sources are defined that enable us to build the missing NightHawk
+  binary image
+  We expect the validation logic to throw an exception
+  """
+  pass
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Test the fully dockerized benchmark class
 """
@@ -11,46 +10,47 @@ from src.lib.benchmark.fully_dockerized_benchmark import Benchmark
 
 
 def test_images_only_config():
-  """
-  Test benchmark validation logic
-  """
+  """Test benchmark validation logic."""
   pass
 
 
 def test_no_envoy_image_no_sources():
-  """
-  Test benchmark validation logic.  No Envoy image is specified, we
-  expect the validation logic to throw an exception since no sources are present
+  """Test benchmark validation logic.
+
+  No Envoy image is specified, we expect the validation logic to
+  throw an exception since no sources are present
   """
   pass
 
 def test_source_to_build_envoy():
-  """
+  """Validate we can build images from source.
+
   Validate that sources are defined that enable us to build the Envoy image
   We do not expect the validation logic to throw an exception
   """
   pass
 
 def test_no_source_to_build_envoy():
-  """
+  """Validate that we fail to build images without sources.
+
   Validate that no sources are present that enable us to build the missing Envoy image
   We expect the validation logic to throw an exception
   """
   pass
 
 def test_no_source_to_build_nh():
-  """
+  """Validate that we fail to build nighthawk without sources.
+
   Validate that no sources are defined that enable us to build the missing NightHawk
-  benchmark image
-  We expect the validation logic to throw an exception
+  benchmark image.  We expect the validation logic to throw an exception
   """
   pass
 
 def test_no_source_to_build_nh2():
-  """
+  """Validate that we fail to build nighthawk without sources.
+
   Validate that no sources are defined that enable us to build the missing NightHawk
-  binary image
-  We expect the validation logic to throw an exception
+  binary image. We expect the validation logic to throw an exception
   """
   pass
 

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -11,9 +11,15 @@ log = logging.getLogger(__name__)
 
 
 def run_command(cmd, **kwargs):
+  """Run the specified command returning its output to the caller.
+
+  Args:
+      cmd: The command to be executed
+      kwargs: Additional optional arguments provided to check_output
+
+  Returns:
+      The output produced by the command
   """
-    Run the specified command returning its string output to the caller
-    """
   output = ''
   try:
     log.debug(f"Executing command: {cmd} with args {kwargs}")

--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -1,6 +1,14 @@
 """
 Constants module
 """
-
+"""
+The DOCKER_SOCKET_PATH identifies the unix socket creatd by the docker
+daemon.  In its absense any operations interacting with docker will fail.
+"""
 DOCKER_SOCKET_PATH = '/var/run/docker.sock'
+"""
+NIGHTHAWK_EXTERNAL_TEST_DIR is the location within the nighthawk-benchmark container
+where user provided test are mounted. The benchmark discovers all tests in this path,
+in the container, and runs them
+"""
 NIGHTHAWK_EXTERNAL_TEST_DIR = '/usr/local/bin/benchmarks/benchmarks.runfiles/nighthawk/benchmarks/external_tests/'

--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -1,0 +1,6 @@
+"""
+Constants module
+"""
+
+DOCKER_SOCKET_PATH = '/var/run/docker.sock'
+NIGHTHAWK_EXTERNAL_TEST_DIR = '/usr/local/bin/benchmarks/benchmarks.runfiles/nighthawk/benchmarks/external_tests/'

--- a/salvo/src/lib/docker_image.py
+++ b/salvo/src/lib/docker_image.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
 """
-This module contains abstracts running a docker image
+This module contains abstracts running a docker image.
 """
 
 import json
@@ -17,29 +16,46 @@ log = logging.getLogger(__name__)
 
 
 class DockerImage():
-  """
-  This class is a wrapper to encapsulate docker operations
+  """This class is a wrapper to encapsulate docker operations.
 
   It uses an available docker python module which handles the
   heavy lifting for manipulating images.
   """
 
   def __init__(self):
+    """Initialize the docker client context."""
     self._client = docker.from_env()
 
   def pull_image(self, image_name):
-    """Pull the identified docker image"""
+    """Pull the identified docker image.
+    Args:
+        image_name: The image that is to be executed
+
+    Returns:
+        An Image object for the requested container
+    """
     return self._client.images.pull(image_name)
 
   def list_images(self):
-    """List all available docker images"""
+    """List all available docker images.
+
+    Returns:
+        A list of image tags available on the local host
+    """
     return self._client.images.list()
 
   def run_image(self, image_name, **kwargs):
-    """
-    Execute the identified docker image
+    """Execute the identified docker image.
 
     The user must specify the command to run and any environment
     variables required
+
+    Args:
+        image_name: The image that is to be executed
+        kwargs:  Additional arguments to pass to the invocation of
+          the docker image
+
+    Returns:
+        The output produced from executing the specified container
     """
     return self._client.containers.run(image_name, stdout=True, stderr=True, detach=False, **kwargs)

--- a/salvo/src/lib/docker_volume.py
+++ b/salvo/src/lib/docker_volume.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 This module builds the volume mapping structure passed to a docker image 
 """
@@ -10,25 +9,34 @@ import logging
 import docker
 
 from google.protobuf.json_format import (Error, MessageToJson)
+from src.lib.constants import (DOCKER_SOCKET_PATH, NIGHTHAWK_EXTERNAL_TEST_DIR)
 
 from api.docker_volume_pb2 import Volume, VolumeProperties
 
 log = logging.getLogger(__name__)
 
-def generate_volume_config(output_dir, test_dir=None):
-  """
-  Generates the volumes config necessary for a container to run.
+def generate_volume_config(output_dir, test_dir=''):
+  """Generates the volumes config necessary for a container to run.
+
   The docker path is hardcoded at the moment.  The output directory
   is mounted read-write and the test directory if specified is mounted
   read-only
+
+  Args:
+    output_dir: The directory where the benchmark artifacts are placed
+    test_dir: If specified, identifies the location of user supplied tests
+
+  Returns:
+    A map specifying the local and remote mount paths, and whether each
+    mount path is read-only, or read-write
   """
   volume_cfg = Volume()
 
   # Setup the docker socket
   properties = VolumeProperties()
-  properties.bind = '/var/run/docker.sock'
+  properties.bind = DOCKER_SOCKET_PATH
   properties.mode = 'rw'
-  volume_cfg.volumes['/var/run/docker.sock'].CopyFrom(properties)
+  volume_cfg.volumes[DOCKER_SOCKET_PATH].CopyFrom(properties)
 
   # Setup the output directory
   properties = VolumeProperties()
@@ -39,7 +47,7 @@ def generate_volume_config(output_dir, test_dir=None):
   # Setup the test directory
   if test_dir:
     properties = VolumeProperties()
-    properties.bind = '/usr/local/bin/benchmarks/benchmarks.runfiles/nighthawk/benchmarks/external_tests/'
+    properties.bind = NIGHTHAWK_EXTERNAL_TEST_DIR
     properties.mode = 'ro'
     volume_cfg.volumes[test_dir].CopyFrom(properties)
 

--- a/salvo/src/lib/docker_volume.py
+++ b/salvo/src/lib/docker_volume.py
@@ -15,6 +15,7 @@ from api.docker_volume_pb2 import Volume, VolumeProperties
 
 log = logging.getLogger(__name__)
 
+
 def generate_volume_config(output_dir, test_dir=''):
   """Generates the volumes config necessary for a container to run.
 

--- a/salvo/src/lib/job_control_loader.py
+++ b/salvo/src/lib/job_control_loader.py
@@ -13,9 +13,17 @@ log = logging.getLogger(__name__)
 
 
 def _load_json_doc(filename):
+  """Load a disk file as JSON.
+
+  This function reads the specified filename and parses the contents
+  as JSON.
+
+  Args:
+      filename: The file whose contents are to be read as JSON data
+
+  Returns:
+      A dictionary representation of the file contents
   """
-    Load a disk file as JSON
-    """
   contents = None
   log.debug(f"Opening JSON file {filename}")
   try:
@@ -30,9 +38,17 @@ def _load_json_doc(filename):
 
 
 def _load_yaml_doc(filename):
+  """Load a disk file as YAML.
+
+  This function reads the specified filename and parses the contents
+  as YAML.
+
+  Args:
+      filename: The file whose contents are to be read as YAML data
+
+  Returns:
+      A dictionary representation of the file contents
   """
-    Load a disk file as YAML
-    """
   log.debug(f"Opening YAML file {filename}")
   contents = None
   try:
@@ -48,9 +64,18 @@ def _load_yaml_doc(filename):
 
 
 def load_control_doc(filename):
+  """Return a JobControl object from the identified filename.
+
+  This function uses the extension of the specified file to read its
+  contents as YAML or JSON
+
+  Args:
+      filename: The file whose contents are to be read and stored
+        in a dictionary
+
+  Returns:
+      A dictionary representation of the file contents
   """
-    Return a JobControl object from the identified filename
-    """
   contents = None
 
   # Try loading the contents based on the file extension

--- a/salvo/src/lib/job_control_loader.py
+++ b/salvo/src/lib/job_control_loader.py
@@ -22,7 +22,8 @@ def _load_json_doc(filename):
       filename: The file whose contents are to be read as JSON data
 
   Returns:
-      A dictionary representation of the file contents
+      A JobControl object populated with the contestns from the
+      specified JSON file
   """
   contents = None
   log.debug(f"Opening JSON file {filename}")
@@ -47,7 +48,8 @@ def _load_yaml_doc(filename):
       filename: The file whose contents are to be read as YAML data
 
   Returns:
-      A dictionary representation of the file contents
+      A JobControl object populated with the contestns from the
+      specified YAML file
   """
   log.debug(f"Opening YAML file {filename}")
   contents = None
@@ -74,7 +76,8 @@ def load_control_doc(filename):
         in a dictionary
 
   Returns:
-      A dictionary representation of the file contents
+      A JobControl object populated with the contestns from the
+      specified filename
   """
   contents = None
 

--- a/salvo/src/lib/test_docker_image.py
+++ b/salvo/src/lib/test_docker_image.py
@@ -10,13 +10,18 @@ import pytest
 
 site.addsitedir("src")
 
+from src.lib.constants import DOCKER_SOCKET_PATH
 from lib.docker_image import DockerImage
 
 
 def test_pull_image():
-  """Test retrieving an image"""
+  """Test retrieving an image.
 
-  if not os.path.exists("/var/run/docker.sock"):
+  Verify that we can pull a docker image specifying only
+  its name and tag
+  """
+
+  if not os.path.exists(DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
   docker_image = DockerImage()
@@ -25,9 +30,14 @@ def test_pull_image():
 
 
 def test_run_image():
-  """Test executing a command in an image"""
+  """Test executing a command in an image.
 
-  if not os.path.exists("/var/run/docker.sock"):
+  Verify that we can construct the parameters needed to execute
+  a given docker image.  We verify that the output contains
+  the expected output from the issued command
+  """
+
+  if not os.path.exists(DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
   env = ['key1=val1', 'key2=val2']
@@ -45,9 +55,12 @@ def test_run_image():
 
 
 def test_list_images():
-  """Test listing available images"""
+  """Test listing available images.
 
-  if not os.path.exists("/var/run/docker.sock"):
+  Verify that we can list all existing cached docker images.
+  """
+
+  if not os.path.exists(DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
   docker_image = DockerImage()

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Test module to validate parsing of the job control document
 """
@@ -17,9 +16,16 @@ from api.docker_volume_pb2 import (Volume, VolumeProperties)
 
 
 def _write_object_to_disk(pb_obj, path):
+  """Store a formatted json document to disk.
+
+  Args:
+      pb_obj: The Protocol Buffer object to be serialized
+      path: The file to which the object's contents are
+        written
+
+  Returns:
+      None
   """
-    Store a formatted json document to disk
-    """
   json_obj = MessageToJson(pb_obj, indent=2)
   with open(path, 'w') as json_doc:
     json_doc.write(json_obj)
@@ -30,9 +36,17 @@ def _write_object_to_disk(pb_obj, path):
 
 
 def _serialize_and_read_object(pb_obj):
+  """Serialize a protobuf object to disk.
+
+  Serialize the protobuf object to disk and re-read it to
+  verify it is JSON.
+
+  Args:
+      pb_obj: The Protocol Buffer object to be serialized
+
+  Returns:
+      None
   """
-    Serialize a protobuf object to disk and verify we can re-read it as JSON
-    """
   with tempfile.NamedTemporaryFile(mode='w', delete=True) as tmp:
     _write_object_to_disk(pb_obj, tmp.name)
 
@@ -43,9 +57,18 @@ def _serialize_and_read_object(pb_obj):
 
 
 def _validate_job_control_object(job_control):
+  """Common verification method for a job control object.
+
+  This method reads an object and verifies its data fields
+  match a predetermined set of data
+
+  Args:
+      job_control: The Protocol Buffer object whose data fields
+        are to be examined and verified
+
+  Returns:
+      None
   """
-    Common verification function for a job control object
-    """
   assert job_control is not None
 
   # Verify execution location
@@ -104,9 +127,12 @@ def _validate_job_control_object(job_control):
 
 
 def test_control_doc_parse_yaml():
+  """Verify that we can consume a yaml formatted control document.
+
+  This method reads a yaml representation of the job control document,
+  serializes it, then verifies that the serialized data matches the
+  input.
   """
-    Verify that we can consume a yaml formatted control document
-    """
   control_yaml = """
       remote: true
       scavengingBenchmark: true
@@ -145,9 +171,12 @@ def test_control_doc_parse_yaml():
 
 
 def test_control_doc_parse():
+  """Verify that we can consume a JSON formatted control document.
+
+  This method reads a JSON representation of the job control document,
+  serializes it, then verifies that the serialized data matches the
+  input.
   """
-    Verify that we can consume a JSON formatted control document
-    """
 
   control_json = """
     {
@@ -197,9 +226,11 @@ def test_control_doc_parse():
 
 
 def test_generate_control_doc():
+  """Verify that we can serialize an object to a file in JSON format.
+
+  This method reads a JSON representation of the job control document,
+  serializes it, then verifies that the serialized data can be re-read.
   """
-    Verify that we can serialize an object to a file in JSON format
-    """
   job_control = JobControl()
   job_control.remote = True
   job_control.scavenging_benchmark = True
@@ -231,9 +262,11 @@ def test_generate_control_doc():
 
 
 def _test_docker_volume_generation():
+  """Verify construction of the volume mount map.
+
+  This test creates the volume and mount map we provide to a docker container.
+  We verify that the structure can be serialized and read as JSON.
   """
-    Verify construction of the volume mount map that we provide to a docker container
-    """
   volume_cfg = Volume()
 
   props = VolumeProperties()


### PR DESCRIPTION
This change adds a skeleton for the fully dockerized benchmark flow.

This benchmark method uses docker images for  Envoy, the NightHawk benchmark framework, and the NightHawk binaries.  

Users specify a location where external tests are mapped into the benchmark container and executed.

cc: @mum4k, @oschaaf, @htuch 

Signed-off-by: Alvin Baptiste <alvinsb@gmail.com>