### PR TITLE
[Salvo] Add method implementation and populate unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/__pycache__/*
 bazel-*
 **/venv/*
+**/.pytype/*

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -6,11 +6,20 @@
 # in build logs
 set -e
 
+
+function install_deps() {
+  ./install_deps.sh
+}
+
 # Build the salvo framework
 function build_salvo() {
   echo "Building Salvo"
   pushd salvo
+
+  install_deps
   bazel build //...
+  tools/typecheck.sh
+
   popd
 }
  
@@ -18,8 +27,8 @@ function build_salvo() {
 function test_salvo() {
   echo "Running Salvo unit tests"
   pushd salvo
-  ./install_deps.sh
 
+  install_deps
   bazel test //...
 
   popd

--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -6,6 +6,12 @@ then
   exit 0
 fi
 
+if [ -f ${HOME}/.salvo_deps_installed ]
+then
+  echo "Dependencies already installed. Remove \"${HOME}/.salvo_deps_installed\" to reinstall."
+  exit 0
+fi
+
 /usr/bin/apt update
 /usr/bin/apt -y install \
   docker.io \
@@ -16,3 +22,5 @@ fi
 pip3 install --upgrade --user pip
 pip3 install --upgrade --user setuptool
 pip3 install --user -r requirements.txt
+
+touch ${HOME}/.salvo_deps_installed

--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -15,5 +15,4 @@ fi
 
 pip3 install --upgrade --user pip
 pip3 install --upgrade --user setuptool
-pip3 install --user pybind11
 pip3 install --user -r requirements.txt

--- a/salvo/requirements.txt
+++ b/salvo/requirements.txt
@@ -18,13 +18,14 @@ networkx==2.5
 ninja==1.10.0.post2
 pluggy==0.6.0
 py==1.5.2
+pybind11==2.6.1
 pygobject==3.26.1
 pytest==3.3.2
 python-apt==1.6.5+ubuntu0.3
 python-dateutil==2.8.1
 pytype==2020.11.12
 PyYAML==5.1
-requests==2.20.0
+requests==2.18.4
 s3transfer==0.3.3
 six==1.15.0
 typed-ast==1.4.1

--- a/salvo/src/lib/benchmark/BUILD
+++ b/salvo/src/lib/benchmark/BUILD
@@ -19,6 +19,17 @@ py_library(
 )
 
 py_test(
+  name = "test_base_benchmark",
+  srcs = [ "test_base_benchmark.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      "//src/lib:docker_image",
+      ":benchmark"
+  ],
+)
+
+py_test(
   name = "test_fully_dockerized_benchmark",
   srcs = [ "test_fully_dockerized_benchmark.py" ],
   srcs_version = "PY3",

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -107,6 +107,9 @@ class BaseBenchmark(object):
         a List of required image names that are retrievable. If any image is
           unavailable, we return an empty list. The intent is for the caller to
           build the necessary images.
+
+    Raises:
+        an Exception if a requested image is unavailable.
     """
     retrieved_images = []
     images = self.get_images()
@@ -124,7 +127,7 @@ class BaseBenchmark(object):
         retrieved_image = self._docker_image.pull_image(image)
         log.debug(f"Retrieved image: {retrieved_image} for {image}")
         if retrieved_image is None:
-          return []
+            raise Exception("Unable to retrieve image: %s" % image)
         retrieved_images.append(retrieved_image)
 
     return retrieved_images

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -9,8 +9,8 @@ import logging
 
 import src.lib.benchmark.base_benchmark as base_benchmark
 import src.lib.docker_image as docker_image
-from api.control_pb2 import JobControl
-from api.image_pb2 import DockerImages
+import api.control_pb2 as proto_control
+import api.image_pb2 as proto_image
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +20,8 @@ class Benchmark(base_benchmark.BaseBenchmark):
      All common methods for benchmarks should be defined here.
   """
 
-  def __init__(self, job_control: JobControl, benchmark_name: str) -> None:
+  def __init__(
+      self, job_control: proto_control.JobControl, benchmark_name: str) -> None:
     """Initialize the benchmark class."""
     super(Benchmark, self).__init__(job_control, benchmark_name)
 
@@ -50,7 +51,7 @@ class Benchmark(base_benchmark.BaseBenchmark):
 
     return
 
-  def _verify_sources(self, images: DockerImages) -> None:
+  def _verify_sources(self, images: proto_image.DockerImages) -> None:
     """Validate that sources are available to build a missing image.
 
     Verify that a source definition exists tht can build a missing

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -7,7 +7,7 @@ https://github.com/envoyproxy/nighthawk/blob/master/benchmarks/README.md
 
 import logging
 
-from src.lib.benchmark.base_benchmark import BaseBenchmark
+from src.lib.benchmark.base_benchmark import (BaseBenchmark, get_docker_volumes)
 from api.control_pb2 import JobControl
 from api.image_pb2 import DockerImages
 
@@ -24,25 +24,132 @@ class Benchmark(BaseBenchmark):
     super(Benchmark, self).__init__(job_control, benchmark_name)
 
   def _validate(self) -> None:
-    """Validate that all data required for running a benchmark exist.
+    """Validate that all data required for running a benchmark exists.
+
+    Verify that all required images are present in the control object.
+    If not, verify that sources exist from which we can build the
+    required docker images.
 
     Returns:
         None
     """
-    pass
+    verify_source = False
+    images = self.get_images()
+
+    # Determine whether we need to build the images from source
+    # If so, verify that the required source data is defined
+    verify_source = images is None or \
+        not images.nighthawk_benchmark_image or \
+        not images.nighthawk_binary_image or \
+        not images.envoy_image
+
+    log.debug(f"Source verification needed: {verify_source}")
+    if verify_source:
+      self._verify_sources(images)
+
+    return
 
   def _verify_sources(self, images: DockerImages) -> None:
     """Validate that sources are available to build a missing image.
 
+    Verify that a source definition exists tht can build a missing
+    image needed for the benchmark.
+
     Returns:
         None
+
+    Raises:
+        an Exception if no source definitions allow us to build
+          missing docker images.
     """
-    pass
+    source = self.get_source()
+    if not source:
+      raise Exception("No source configuration specified")
+
+    can_build_envoy = False
+    can_build_nighthawk = False
+
+    for source_def in source:
+      # Cases:
+      # Missing envoy image -> Need to see an envoy source definition
+      # Missing at least one nighthawk image -> Need to see a nighthawk source
+
+      if source_def.identity == source_def.SRCID_UNSPECIFIED:
+        raise Exception("No source identity specified")
+
+      if not images.envoy_image \
+          and source_def.identity == source_def.SRCID_ENVOY and \
+          (source_def.source_path or source_def.source_url):
+        can_build_envoy = True
+
+      if (not images.nighthawk_benchmark_image or not images.nighthawk_binary_image) \
+          and source_def.identity == source_def.SRCID_NIGHTHAWK and \
+          (source_def.source_path or source_def.source_url):
+        can_build_nighthawk = True
+
+      if (not images.envoy_image and not can_build_envoy) or \
+          (not images.nighthawk_benchmark_image or not images.nighthawk_binary_image) \
+              and not can_build_nighthawk:
+        # If the Envoy image is specified, then the validation failed for
+        # NightHawk and vice versa
+        msg = "No source specified to build unspecified {image} image".format(
+            image="NightHawk" if images.envoy_image else "Envoy")
+        raise Exception(msg)
+
 
   def execute_benchmark(self) -> None:
     """Prepare input artifacts and run the benchmark.
 
+    Construct the volume, environment variables, and command line
+    arguments needed to execute the benchmark image.
+
     Returns:
         None
+
+    Raises:
+      NotImplementedError if the benchmark is configured to execute
+        remotely.
     """
     self._validate()
+
+    if self.is_remote():
+      raise NotImplementedError("Local benchmarks only for the moment")
+
+    # pull in environment and set values
+    output_dir = self._control.environment.output_dir
+    test_dir = self._control.environment.test_dir
+    images = self.get_images()
+    log.debug(f"Images: {images.nighthawk_benchmark_image}")
+
+    # 'TMPDIR' is required for successful operation.
+    image_vars = {
+        'NH_DOCKER_IMAGE': images.nighthawk_binary_image,
+        'ENVOY_DOCKER_IMAGE_TO_TEST': images.envoy_image,
+        'TMPDIR': output_dir
+    }
+    log.debug(f"Using environment: {image_vars}")
+
+    volumes = get_docker_volumes(output_dir, test_dir)
+    log.debug(f"Using Volumes: {volumes}")
+    self.set_environment_vars()
+
+    kwargs = {}
+    kwargs['environment'] = image_vars
+    kwargs['command'] = ['./benchmarks', '--log-cli-level=info', '-vvvv']
+    kwargs['volumes'] = volumes
+    kwargs['network_mode'] = 'host'
+    kwargs['tty'] = True
+
+    # TODO: We need to capture stdout and stderr to a file to catch docker
+    # invocation issues. This may help with the escaping that we see happening
+    # on an successful invocation
+    result = self.run_image(images.nighthawk_benchmark_image, **kwargs)
+
+    # FIXME: result needs to be unescaped. We don't use this data and the same
+    # content is available in the nighthawk-human.txt file.
+    log.debug(f"Output: {len(result)} bytes")
+
+    log.info(f"Benchmark output: {output_dir}")
+
+    return
+

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -7,15 +7,15 @@ https://github.com/envoyproxy/nighthawk/blob/master/benchmarks/README.md
 
 import logging
 
-from src.lib.benchmark.base_benchmark import (BaseBenchmark, get_docker_volumes)
+import src.lib.benchmark.base_benchmark as base_benchmark
+import src.lib.docker_image as docker_image
 from api.control_pb2 import JobControl
 from api.image_pb2 import DockerImages
-from src.lib.docker_image import DockerRunParameters
 
 log = logging.getLogger(__name__)
 
 
-class Benchmark(BaseBenchmark):
+class Benchmark(base_benchmark.BaseBenchmark):
   """This is the base class from which all benchmark objecs are derived.
      All common methods for benchmarks should be defined here.
   """
@@ -130,11 +130,11 @@ class Benchmark(BaseBenchmark):
     }
     log.debug(f"Using environment: {image_vars}")
 
-    volumes = get_docker_volumes(output_dir, test_dir)
+    volumes = base_benchmark.get_docker_volumes(output_dir, test_dir)
     log.debug(f"Using Volumes: {volumes}")
-    self.set_environment_vars()
+    self._set_environment_vars()
 
-    run_parameters = DockerRunParameters(
+    run_parameters = docker_image.DockerRunParameters(
         command=['./benchmarks', '--log-cli-level=info', '-vvvv'],
         environment=image_vars,
         volumes=volumes,
@@ -146,6 +146,8 @@ class Benchmark(BaseBenchmark):
     # invocation issues. This may help with the escaping that we see happening
     # on an successful invocation
     result = self.run_image(images.nighthawk_benchmark_image, run_parameters)
+
+    self._clear_environment_vars()
 
     # FIXME: result needs to be unescaped. We don't use this data and the same
     # content is available in the nighthawk-human.txt file.

--- a/salvo/src/lib/benchmark/test_base_benchmark.py
+++ b/salvo/src/lib/benchmark/test_base_benchmark.py
@@ -1,0 +1,88 @@
+"""
+Test the base benchmark class
+"""
+import os
+import copy
+import pytest
+
+import api.control_pb2 as proto_control
+import src.lib.benchmark.base_benchmark as base_benchmark
+
+def test_environment_variables():
+  """Test that the specified environment variables are set for a
+      benchmark.
+
+      We copy the environment variables for verification and clear
+      the variables that we set so that we do not pollute other
+      tests.
+  """
+  job_control = proto_control.JobControl()
+  environ = job_control.environment
+  environ.variables["TMP_DIR"] = "/home/user/nighthawk_output"
+  environ.variables["TEST_VAR1"] = "TEST_VALUE1"
+  environ.variables["TEST_VAR2"] = "TEST_VALUE2"
+  environ.variables["TEST_VAR3"] = "TEST_VALUE3"
+  environ.test_version = job_control.environment.IPV_V4ONLY
+  environ.envoy_path = "a_proxy_called_envoy"
+
+  benchmark = base_benchmark.BaseBenchmark(job_control, "test_benchmark")
+  benchmark._set_environment_vars()
+
+  expected_vars = {
+      'TMP_DIR': '/home/user/nighthawk_output',
+      'TEST_VAR1': 'TEST_VALUE1',
+      'TEST_VAR2': 'TEST_VALUE2',
+      'TEST_VAR3': 'TEST_VALUE3',
+      'ENVOY_IP_TEST_VERSIONS': 'v4only',
+      'ENVOY_PATH': 'a_proxy_called_envoy'
+  }
+
+  environment_variables = copy.deepcopy(os.environ)
+  benchmark._clear_environment_vars()
+
+  for (key, value) in expected_vars.items():
+    assert environment_variables[key] == value
+
+def test_no_environment_variables_exception():
+  """Test that we raise an exception if the environment is not configured."""
+  job_control = proto_control.JobControl()
+
+  benchmark = base_benchmark.BaseBenchmark(job_control, "test_benchmark")
+  with pytest.raises(Exception) as environment_exception:
+    benchmark._set_environment_vars()
+
+  assert str(environment_exception.value) == \
+      "No IP version is specified for the benchmark"
+
+def test_minimal_environment_variables():
+  """Test that setting the required variables works and no extra variables are
+     set.
+  """
+  job_control = proto_control.JobControl()
+  environ = job_control.environment
+  environ.test_version = job_control.environment.IPV_V4ONLY
+
+  benchmark = base_benchmark.BaseBenchmark(job_control, "test_benchmark")
+  benchmark._set_environment_vars()
+
+  not_expected_vars = {
+      'TMP_DIR': '/home/user/nighthawk_output',
+      'TEST_VAR1': 'TEST_VALUE1',
+      'TEST_VAR2': 'TEST_VALUE2',
+      'TEST_VAR3': 'TEST_VALUE3',
+      'ENVOY_PATH': 'a_proxy_called_envoy'
+  }
+
+  expected_vars = {
+      'ENVOY_IP_TEST_VERSIONS': 'v4only',
+  }
+
+  for (key, value) in expected_vars.items():
+    assert os.environ[key] == value
+
+  for (key, _) in not_expected_vars.items():
+    assert key not in os.environ
+
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -2,17 +2,54 @@
 Test the fully dockerized benchmark class
 """
 
-import site
 import pytest
+from unittest import mock
 
 from api.control_pb2 import JobControl
 from src.lib.benchmark.fully_dockerized_benchmark import Benchmark
 
 
 def test_images_only_config():
-  """Test benchmark validation logic."""
-  pass
+  """Test benchmark validation logic.
 
+  Validate that we attempt to run the specified docker image
+  when all parameters are present.
+  """
+  # create a valid configuration defining images only for benchmark
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.reuse_nh_images = True
+  docker_images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:test_images_only_config"
+  docker_images.nighthawk_binary_image = \
+      "envoyproxy/nighthawk-dev:test_images_only_config"
+  docker_images.envoy_image = \
+      "envoyproxy/envoy-dev:f61b096f6a2dd3a9c74b9a9369a6ea398dbe1f0f"
+
+  env = job_control.environment
+  env.variables["TMP_DIR"] = "/home/ubuntu/nighthawk_output"
+  env.test_version = env.IPV_V4ONLY
+  env.envoy_path = "envoy"
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark shoud not throw an exception
+  # Mock the container invocation so that we don't try to pull an image
+  with mock.patch('docker.models.containers.ContainerCollection.run') as docker_mock:
+    benchmark.execute_benchmark()
+    docker_mock.assert_called_once_with(
+        'envoyproxy/nighthawk-benchmark-dev:test_images_only_config',
+        command=mock.ANY,
+        detach=False,
+        environment=mock.ANY,
+        network_mode='host',
+        stderr=True,
+        stdout=True,
+        tty=True,
+        volumes=mock.ANY)
 
 def test_no_envoy_image_no_sources():
   """Test benchmark validation logic.
@@ -20,7 +57,26 @@ def test_no_envoy_image_no_sources():
   No Envoy image is specified, we expect the validation logic to
   throw an exception since no sources are present
   """
-  pass
+  # create a valid configuration with a missing Envoy image
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.reuse_nh_images = True
+  docker_images.reuse_nh_images = True
+  docker_images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:test_missing_envoy_image"
+  docker_images.nighthawk_binary_image = \
+      "envoyproxy/nighthawk-dev:test_missing_envoy_image"
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark shoud not throw an exception
+  with pytest.raises(Exception) as validation_exception:
+    benchmark.execute_benchmark()
+
+  assert str(validation_exception.value) == "No source configuration specified"
 
 
 def test_source_to_build_envoy():
@@ -29,34 +85,166 @@ def test_source_to_build_envoy():
   Validate that sources are defined that enable us to build the Envoy image
   We do not expect the validation logic to throw an exception
   """
-  pass
+  # create a valid configuration with a missing Envoy image
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.reuse_nh_images = True
+  docker_images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:test_source_present_to_build_envoy"
+  docker_images.nighthawk_binary_image = \
+      "envoyproxy/nighthawk-dev:test_source_present_to_build_envoy"
+
+  envoy_source = job_control.source.add()
+  envoy_source.identity = envoy_source.SRCID_ENVOY
+  envoy_source.source_path = "/home/ubuntu/envoy"
+  envoy_source.source_url = "https://github.com/envoyproxy/envoy.git"
+  envoy_source.branch = "master"
+  envoy_source.commit_hash = "hash_doesnt_really_matter_here"
+
+  env = job_control.environment
+  env.test_version = env.IPV_V4ONLY
+  env.envoy_path = 'envoy'
+  env.output_dir = 'some_output_dir'
+  env.test_dir = 'some_test_dir'
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Mock the container invocation so that we don't try to pull an image
+  with mock.patch('docker.models.containers.ContainerCollection.run') as docker_mock:
+    benchmark.execute_benchmark()
+    docker_mock.assert_called_once_with(
+        'envoyproxy/nighthawk-benchmark-dev:test_source_present_to_build_envoy',
+        command=mock.ANY,
+        detach=False,
+        environment=mock.ANY,
+        network_mode='host',
+        stderr=True,
+        stdout=True,
+        tty=True,
+        volumes=mock.ANY)
 
 
 def test_no_source_to_build_envoy():
   """Validate that we fail to build images without sources.
 
-  Validate that no sources are present that enable us to build the missing Envoy image
+  Validate that no sources are present that enable us to build the missing
+  Envoy image
+
   We expect the validation logic to throw an exception
   """
-  pass
+  # create a configuration with a missing Envoy image
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.reuse_nh_images = True
+  docker_images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:test_no_source_present_to_build_envoy"
+  docker_images.nighthawk_binary_image = \
+      "envoyproxy/nighthawk-dev:test_no_source_present_to_build_envoy"
+
+  envoy_source = job_control.source.add()
+
+  # Denote that the soure is for nighthawk.  Values aren't really checked at
+  # this stage since we have a missing Envoy image and a nighthawk source
+  # validation should fail.
+  envoy_source.identity = envoy_source.SRCID_NIGHTHAWK
+  envoy_source.source_path = "/home/ubuntu/envoy"
+  envoy_source.source_url = "https://github.com/envoyproxy/envoy.git"
+  envoy_source.branch = "master"
+  envoy_source.commit_hash = "hash_doesnt_really_matter_here"
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark shoud not throw an exception
+  with pytest.raises(Exception) as validation_exception:
+    benchmark.execute_benchmark()
+
+  assert str(validation_exception.value) == \
+      "No source specified to build unspecified Envoy image"
 
 
 def test_no_source_to_build_nh():
   """Validate that we fail to build nighthawk without sources.
 
-  Validate that no sources are defined that enable us to build the missing NightHawk
-  benchmark image.  We expect the validation logic to throw an exception
+  Validate that no sources are defined that enable us to build the missing
+  NightHawk benchmark image.
+
+  We expect the validation logic to throw an exception
   """
-  pass
+  # create a valid configuration with a missing NightHawk container image
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.reuse_nh_images = True
+  docker_images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:test_no_source_to_build_nh"
+  docker_images.envoy_image = \
+      "envoyproxy/envoy-dev:test_no_source_to_build_nh"
+
+  envoy_source = job_control.source.add()
+
+  # Denote that the soure is for envoy.  Values aren't really checked at this
+  # stage since we have a missing Envoy image and a nighthawk source validation
+  # should fail.
+  envoy_source.identity = envoy_source.SRCID_ENVOY
+  envoy_source.source_path = "/home/ubuntu/envoy"
+  envoy_source.source_url = "https://github.com/envoyproxy/envoy.git"
+  envoy_source.branch = "master"
+  envoy_source.commit_hash = "hash_doesnt_really_matter_here"
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark shoud not throw an exception
+  with pytest.raises(Exception) as validation_exception:
+    benchmark.execute_benchmark()
+
+  assert str(validation_exception.value) == \
+      "No source specified to build unspecified NightHawk image"
 
 
 def test_no_source_to_build_nh2():
   """Validate that we fail to build nighthawk without sources.
 
-  Validate that no sources are defined that enable us to build the missing NightHawk
-  binary image. We expect the validation logic to throw an exception
+  Validate that no sources are defined that enable us to build the missing
+  NightHawk binary image.
+
+  We expect the validation logic to throw an exception
   """
-  pass
+  # create a valid configuration with a missing both NightHawk container images
+  job_control = JobControl()
+  job_control.remote = False
+  job_control.scavenging_benchmark = True
+
+  docker_images = job_control.images
+  docker_images.envoy_image = \
+      "envoyproxy/envoy-dev:test_no_source_present_to_build_both_nighthawk_images"
+
+  envoy_source = job_control.source.add()
+
+  # Denote that the soure is for envoy.  Values aren't really checked at this
+  # stage since we have a missing Envoy image and a nighthawk source validation
+  # should fail.
+  envoy_source.identity = envoy_source.SRCID_ENVOY
+  envoy_source.source_path = "/home/ubuntu/envoy"
+  envoy_source.source_url = "https://github.com/envoyproxy/envoy.git"
+  envoy_source.branch = "master"
+  envoy_source.commit_hash = "hash_doesnt_really_matter_here"
+
+  benchmark = Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark shoud not throw an exception
+  with pytest.raises(Exception) as validation_exception:
+    benchmark.execute_benchmark()
+
+  assert str(validation_exception.value) == \
+      "No source specified to build unspecified NightHawk image"
 
 
 if __name__ == '__main__':

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -3,22 +3,26 @@ Module to execute a command and return the output generated.  Returns both
 stdout and stderr in the buffer.  We also convert bytes objects to a string
 so callers manipulate one type of object
 """
+import collections
 import shlex
 import subprocess
 import logging
 
 log = logging.getLogger(__name__)
 
+CommandParameters = collections.namedtuple("CommandParameters", [
+    'cwd', # A string specifying the working directory ofthe executing command
+])
 
-def run_command(cmd: str, **kwargs) -> str:
+def run_command(cmd: str, parameters: CommandParameters) -> str:
   """Run the specified command returning its output to the caller.
 
   Args:
       cmd: The command to be executed
-      kwargs: Additional optional arguments provided to check_output. Most
-        importantly, in kwargs we specify 'cwd' which is the intended working
-        directory where the command is to be executed.  Other paramters supported
-        by the subprocess module are supported for finer control of the commands
+      parameters: Additional arguments provided to check_output. Most
+        importantly, we specify 'cwd' which is the intended working directory
+        where the command is to be executed.  Other parameters supported
+        by the subprocess module will be added as they become necessary for
         execution.
 
   Returns:
@@ -30,10 +34,10 @@ def run_command(cmd: str, **kwargs) -> str:
   """
   output = ''
   try:
-    log.debug(f"Executing command: [{cmd}] with args [{kwargs}]")
+    log.debug(f"Executing command: [{cmd}] with args [{**parameters._asdict()}]")
     cmd_array = shlex.split(cmd)
     output = subprocess.check_output(
-      cmd_array, stderr=subprocess.STDOUT, **kwargs)
+      cmd_array, stderr=subprocess.STDOUT, **parameters._asdict())
 
     if isinstance(output, bytes):
       output = output.decode('utf-8').strip()

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -3,15 +3,17 @@ Module to execute a command and return the output generated.  Returns both
 stdout and stderr in the buffer.  We also convert bytes objects to a string
 so callers manipulate one type of object
 """
-import collections
 import shlex
 import subprocess
+import typing
 import logging
 
 log = logging.getLogger(__name__)
 
-CommandParameters = collections.namedtuple("CommandParameters", [
-    'cwd', # A string specifying the working directory ofthe executing command
+# Encapsulates parameters and their values required to execute a command
+CommandParameters = typing.NamedTuple("CommandParameters", [
+    ('cwd', str), # A string specifying the working directory of the executing
+                  # command
 ])
 
 def run_command(cmd: str, parameters: CommandParameters) -> str:
@@ -37,7 +39,7 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
     log.debug(f"Executing command: [{cmd}] with args [{parameters._asdict()}]")
     cmd_array = shlex.split(cmd)
     output = subprocess.check_output(
-      cmd_array, stderr=subprocess.STDOUT, **parameters._asdict())
+        cmd_array, stderr=subprocess.STDOUT, **parameters._asdict())
 
     if isinstance(output, bytes):
       output = output.decode('utf-8').strip()

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -34,7 +34,7 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
   """
   output = ''
   try:
-    log.debug(f"Executing command: [{cmd}] with args [{**parameters._asdict()}]")
+    log.debug(f"Executing command: [{cmd}] with args [{parameters._asdict()}]")
     cmd_array = shlex.split(cmd)
     output = subprocess.check_output(
       cmd_array, stderr=subprocess.STDOUT, **parameters._asdict())

--- a/salvo/src/lib/docker_image.py
+++ b/salvo/src/lib/docker_image.py
@@ -3,16 +3,11 @@ This module contains abstracts running a docker image.
 """
 
 import collections
-import json
 import logging
 
 # Ref: https://docker-py.readthedocs.io/en/stable/index.html
 import docker
 from typing import List
-
-from google.protobuf.json_format import (Error, MessageToJson)
-
-from api.docker_volume_pb2 import Volume, VolumeProperties
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +43,7 @@ class DockerImage():
     """
     return self._client.images.pull(image_name)
 
-  def list_images(self) -> list:
+  def list_images(self) -> List[str]:
     """List all available docker image tags.
 
     This method returns all the existing image tags from the local host. This is used

--- a/salvo/src/lib/docker_image.py
+++ b/salvo/src/lib/docker_image.py
@@ -11,9 +11,12 @@ from typing import List
 
 log = logging.getLogger(__name__)
 
+# TODO(abaptiste): consider using pytype annotations in the NamedTuple
+
+# Provides parameters required for executing a docker container
 DockerRunParameters = collections.namedtuple("DockerRunParameters", [
-    'environment',  # a dict with environment variable to set in the container
-    'command',      # a string containing the command to execute
+    'environment',  # a dict with environment variables to set in the container
+    'command',      # a lexical split string containing the command to execute
     'volumes',      # a dict with the volumes mounted in the container
     'network_mode', # a string that specifies the network stack used
     'tty'           # a boolean indicating if a pseudo-tty is allocated
@@ -46,8 +49,9 @@ class DockerImage():
   def list_images(self) -> List[str]:
     """List all available docker image tags.
 
-    This method returns all the existing image tags from the local host. This is used
-    to determine whether the envoy image already exists before we attempt to rebuild it
+    This method returns all the existing image tags from the local host. This
+    is used to determine whether the envoy image already exists before we
+    attempt to rebuild it
 
     Returns:
         A list of image tags available on the local host
@@ -72,8 +76,9 @@ class DockerImage():
           documented here https://docker-py.readthedocs.io/en/stable/index.html
 
     Returns:
-        A bytearray containing the output produced from executing the specified container
+        A bytearray containing the output produced from executing the specified
+          container
     """
 
-    return self._client.containers.run(image_name, stdout=True, stderr=True, detach=False,
-                                       **run_parameters._asdict())
+    return self._client.containers.run(image_name, stdout=True, stderr=True,
+                                       detach=False, **run_parameters._asdict())

--- a/salvo/src/lib/test_docker_image.py
+++ b/salvo/src/lib/test_docker_image.py
@@ -11,7 +11,7 @@ import pytest
 site.addsitedir("src")
 
 from src.lib.constants import DOCKER_SOCKET_PATH
-from src.lib.docker_image import DockerImage
+from src.lib.docker_image import (DockerImage, DockerRunParameters)
 
 
 def test_pull_image():
@@ -45,10 +45,14 @@ def test_run_image():
   image_name = 'amazonlinux:2'
 
   docker_image = DockerImage()
-  kwargs = {}
-  kwargs['environment'] = env
-  kwargs['command'] = cmd
-  result = docker_image.run_image(image_name, **kwargs)
+  run_parameters = DockerRunParameters(
+      environment=env,
+      command=cmd,
+      volumes={},
+      network_mode='host',
+      tty=True
+  )
+  result = docker_image.run_image(image_name, run_parameters)
 
   assert result is not None
   assert re.match(r'[0-9\-a-z]', result.decode('utf-8')) is not None

--- a/salvo/src/lib/test_docker_image.py
+++ b/salvo/src/lib/test_docker_image.py
@@ -11,7 +11,7 @@ import pytest
 site.addsitedir("src")
 
 from src.lib.constants import DOCKER_SOCKET_PATH
-from lib.docker_image import DockerImage
+from src.lib.docker_image import DockerImage
 
 
 def test_pull_image():

--- a/salvo/src/lib/test_docker_image.py
+++ b/salvo/src/lib/test_docker_image.py
@@ -5,14 +5,10 @@ Test Docker interactions
 
 import os
 import re
-import site
 import pytest
 
-site.addsitedir("src")
-
-from src.lib.constants import DOCKER_SOCKET_PATH
-from src.lib.docker_image import (DockerImage, DockerRunParameters)
-
+import src.lib.constants as constants
+import src.lib.docker_image as docker_image
 
 def test_pull_image():
   """Test retrieving an image.
@@ -21,11 +17,11 @@ def test_pull_image():
   its name and tag
   """
 
-  if not os.path.exists(DOCKER_SOCKET_PATH):
+  if not os.path.exists(constants.DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
-  docker_image = DockerImage()
-  container = docker_image.pull_image("amazonlinux:2")
+  new_docker_image = docker_image.DockerImage()
+  container = new_docker_image.pull_image("amazonlinux:2")
   assert container is not None
 
 
@@ -37,22 +33,22 @@ def test_run_image():
   the expected output from the issued command
   """
 
-  if not os.path.exists(DOCKER_SOCKET_PATH):
+  if not os.path.exists(constants.DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
   env = ['key1=val1', 'key2=val2']
   cmd = ['uname', '-r']
   image_name = 'amazonlinux:2'
 
-  docker_image = DockerImage()
-  run_parameters = DockerRunParameters(
+  new_docker_image = docker_image.DockerImage()
+  run_parameters = docker_image.DockerRunParameters(
       environment=env,
       command=cmd,
       volumes={},
       network_mode='host',
       tty=True
   )
-  result = docker_image.run_image(image_name, run_parameters)
+  result = new_docker_image.run_image(image_name, run_parameters)
 
   assert result is not None
   assert re.match(r'[0-9\-a-z]', result.decode('utf-8')) is not None
@@ -64,11 +60,11 @@ def test_list_images():
   Verify that we can list all existing cached docker images.
   """
 
-  if not os.path.exists(DOCKER_SOCKET_PATH):
+  if not os.path.exists(constants.DOCKER_SOCKET_PATH):
     pytest.skip("Skipping docker test since no socket is available")
 
-  docker_image = DockerImage()
-  images = docker_image.list_images()
+  new_docker_image = docker_image.DockerImage()
+  images = new_docker_image.list_images()
   assert images != []
 
 

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -12,7 +12,7 @@ import src.lib.job_control_loader as job_ctrl
 
 import api.control_pb2 as proto_control
 import api.source_pb2 as proto_source
-from api.docker_volume_pb2 import (Volume, VolumeProperties)
+import api.docker_volume_pb2 as proto_docker_volume
 
 
 def _write_object_to_disk(pb_obj, path):
@@ -274,19 +274,19 @@ def _test_docker_volume_generation():
   This test creates the volume and mount map we provide to a docker container.
   We verify that the structure can be serialized and read as JSON.
   """
-  volume_cfg = Volume()
+  volume_cfg = proto_docker_volume.Volume()
 
-  props = VolumeProperties()
+  props = proto_docker_volume.VolumeProperties()
   props.bind = constants.DOCKER_SOCKET_PATH
   props.mode = 'ro'
   volume_cfg.volumes[constants.DOCKER_SOCKET_PATH].CopyFrom(props)
 
-  props = VolumeProperties()
+  props = proto_docker_volume.VolumeProperties()
   props.bind = '/home/ubuntu/nighthawk_output'
   props.mode = 'rw'
   volume_cfg.volumes['/home/ubuntu/nighthawk_output'].CopyFrom(props)
 
-  props = VolumeProperties()
+  props = proto_docker_volume.VolumeProperties()
   props.bind = constants.NIGHTHAWK_EXTERNAL_TEST_DIR
   props.mode = 'rw'
   volume_cfg.volumes[constants.NIGHTHAWK_EXTERNAL_TEST_DIR].CopyFrom(props)

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -9,7 +9,7 @@ import pytest
 from google.protobuf.json_format import (MessageToJson)
 
 from src.lib.constants import (DOCKER_SOCKET_PATH, NIGHTHAWK_EXTERNAL_TEST_DIR)
-from job_control_loader import load_control_doc
+from src.lib.job_control_loader import load_control_doc
 from api.control_pb2 import JobControl
 from api.source_pb2 import SourceRepository
 from api.docker_volume_pb2 import (Volume, VolumeProperties)

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -6,12 +6,12 @@ import json
 import tempfile
 import pytest
 
-from google.protobuf.json_format import (MessageToJson)
+import google.protobuf.json_format as json_format
+import src.lib.constants as constants
+import src.lib.job_control_loader as job_ctrl
 
-from src.lib.constants import (DOCKER_SOCKET_PATH, NIGHTHAWK_EXTERNAL_TEST_DIR)
-from src.lib.job_control_loader import load_control_doc
-from api.control_pb2 import JobControl
-from api.source_pb2 import SourceRepository
+import api.control_pb2 as proto_control
+import api.source_pb2 as proto_source
 from api.docker_volume_pb2 import (Volume, VolumeProperties)
 
 
@@ -26,7 +26,7 @@ def _write_object_to_disk(pb_obj, path):
   Returns:
       None
   """
-  json_obj = MessageToJson(pb_obj, indent=2)
+  json_obj = json_format.MessageToJson(pb_obj, indent=2)
   with open(path, 'w') as json_doc:
     json_doc.write(json_obj)
 
@@ -86,14 +86,16 @@ def _validate_job_control_object(job_control):
   saw_envoy = False
   saw_nighthawk = False
   for source in job_control.source:
-    if source.identity == SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
+    if source.identity == \
+        proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
       assert not source.source_path
       assert source.source_url == "https://github.com/envoyproxy/nighthawk.git"
       assert source.branch == "master"
       assert not source.commit_hash
       saw_nighthawk = True
 
-    elif source.identity == SourceRepository.SourceIdentity.SRCID_ENVOY:
+    elif source.identity == \
+        proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:
       assert source.source_path == "/home/ubuntu/envoy"
       assert not source.source_url
       assert source.branch == "master"
@@ -164,7 +166,7 @@ def test_control_doc_parse_yaml():
   with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
     tmp.write(control_yaml)
     tmp.close()
-    job_control = load_control_doc(tmp.name)
+    job_control = job_ctrl.load_control_doc(tmp.name)
     os.unlink(tmp.name)
 
   _validate_job_control_object(job_control)
@@ -219,7 +221,7 @@ def test_control_doc_parse():
   with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
     tmp.write(control_json)
     tmp.close()
-    job_control = load_control_doc(tmp.name)
+    job_control = job_ctrl.load_control_doc(tmp.name)
     os.unlink(tmp.name)
 
   _validate_job_control_object(job_control)
@@ -231,25 +233,30 @@ def test_generate_control_doc():
   This method reads a JSON representation of the job control document,
   serializes it, then verifies that the serialized data can be re-read.
   """
-  job_control = JobControl()
+  job_control = proto_control.JobControl()
   job_control.remote = True
   job_control.scavenging_benchmark = True
 
   nighthawk_source = job_control.source.add()
-  nighthawk_source.identity == SourceRepository.SourceIdentity.SRCID_NIGHTHAWK
+  nighthawk_source.identity = \
+      proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK
   nighthawk_source.source_url = "https://github.com/envoyproxy/nighthawk.git"
   nighthawk_source.branch = "master"
 
   envoy_source = job_control.source.add()
-  envoy_source.identity = SourceRepository.SourceIdentity.SRCID_ENVOY
+  envoy_source.identity = \
+      proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY
   envoy_source.source_path = "/home/ubuntu/envoy"
   envoy_source.branch = "master"
   envoy_source.commit_hash = "random_commit_hash_string"
 
   job_control.images.reuse_nh_images = True
-  job_control.images.nighthawk_benchmark_image = "envoyproxy/nighthawk-benchmark-dev:latest"
-  job_control.images.nighthawk_binary_image = "envoyproxy/nighthawk-dev:latest"
-  job_control.images.envoy_image = "envoyproxy/envoy-dev:f61b096f6a2dd3a9c74b9a9369a6ea398dbe1f0f"
+  job_control.images.nighthawk_benchmark_image = \
+      "envoyproxy/nighthawk-benchmark-dev:latest"
+  job_control.images.nighthawk_binary_image = \
+      "envoyproxy/nighthawk-dev:latest"
+  job_control.images.envoy_image = \
+      "envoyproxy/envoy-dev:f61b096f6a2dd3a9c74b9a9369a6ea398dbe1f0f"
 
   job_control.environment.variables["TMP_DIR"] = "/home/ubuntu/nighthawk_output"
   job_control.environment.test_version = job_control.environment.IPV_V4ONLY
@@ -270,9 +277,9 @@ def _test_docker_volume_generation():
   volume_cfg = Volume()
 
   props = VolumeProperties()
-  props.bind = DOCKER_SOCKET_PATH
+  props.bind = constants.DOCKER_SOCKET_PATH
   props.mode = 'ro'
-  volume_cfg.volumes[DOCKER_SOCKET_PATH].CopyFrom(props)
+  volume_cfg.volumes[constants.DOCKER_SOCKET_PATH].CopyFrom(props)
 
   props = VolumeProperties()
   props.bind = '/home/ubuntu/nighthawk_output'
@@ -280,9 +287,9 @@ def _test_docker_volume_generation():
   volume_cfg.volumes['/home/ubuntu/nighthawk_output'].CopyFrom(props)
 
   props = VolumeProperties()
-  props.bind = NIGHTHAWK_EXTERNAL_TEST_DIR
+  props.bind = constants.NIGHTHAWK_EXTERNAL_TEST_DIR
   props.mode = 'rw'
-  volume_cfg.volumes[NIGHTHAWK_EXTERNAL_TEST_DIR].CopyFrom(props)
+  volume_cfg.volumes[constants.NIGHTHAWK_EXTERNAL_TEST_DIR].CopyFrom(props)
 
   # Verify that we the serialized data is json consumable
   _serialize_and_read_object(volume_cfg)

--- a/salvo/tools/typecheck.sh
+++ b/salvo/tools/typecheck.sh
@@ -5,9 +5,9 @@ set -x
 
 function die()
 {
-  MSG="$1"
+  MESSAGE="$1"
 
-  echo ${MSG}
+  echo ${MESSAGE}
   exit 1
 }
 

--- a/salvo/tools/typecheck.sh
+++ b/salvo/tools/typecheck.sh
@@ -24,5 +24,4 @@ fi
 
 echo $PWD
 
-bazel build //...
 ${PYTYPE} src -P bazel-bin:.


### PR DESCRIPTION
In this PR we add the implementation for the skeleton methods, and the accompanying unit tests.

Doc strings were adjusted based on pylint warnings.  The pytype checks were added to the CI script.  This should resolve https://github.com/envoyproxy/envoy-perf/issues/76.

cc: @mum4k, @landesherr