### PR TITLE
Use a context manager to stop lingering docker images

### DIFF
--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -9,8 +9,8 @@ import logging
 
 import api.control_pb2 as proto_control
 import api.image_pb2 as proto_image
-import src.lib.benchmark.base_benchmark as base_benchmark
-import src.lib.docker.docker_image as docker_image
+from src.lib.benchmark import base_benchmark
+from src.lib.docker import docker_image
 
 log = logging.getLogger(__name__)
 

--- a/salvo/src/lib/docker/BUILD
+++ b/salvo/src/lib/docker/BUILD
@@ -8,7 +8,7 @@ package(
 
 py_library(
     name = "docker_image",
-    data = [
+    srcs = [
         "docker_image.py",
     ],
     deps = [
@@ -18,7 +18,7 @@ py_library(
 
 py_library(
     name = "docker_volume",
-    data = [
+    srcs = [
         "docker_volume.py",
     ],
     deps = [

--- a/salvo/src/lib/docker/test_docker_image.py
+++ b/salvo/src/lib/docker/test_docker_image.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Test Docker interactions
 """
@@ -6,9 +5,11 @@ Test Docker interactions
 import os
 import re
 import pytest
+import docker
+from unittest import mock
 
-import src.lib.constants as constants
-import src.lib.docker.docker_image as docker_image
+from src.lib import constants
+from src.lib.docker import docker_image
 
 
 def test_pull_image():
@@ -68,6 +69,48 @@ def test_list_images():
   images = new_docker_image.list_images()
   assert images != []
 
+def test_list_processes():
+  """Verify that we can list running images."""
+
+  expected_name_list = [
+      "prefix/image_1",
+      "prefix/image_2",
+      "prefix/image_3"
+  ]
+
+  expected_image_list = []
+  for image_name in expected_name_list:
+    mock_container = mock.Mock()
+    mock_container.name = image_name
+    expected_image_list.append(mock_container)
+
+  image_filter = {'status': 'running'}
+
+  new_docker_image = docker_image.DockerImage()
+  with mock.patch('docker.models.containers.ContainerCollection.list',
+                  mock.MagicMock(return_value=expected_image_list)) \
+      as image_list_mock:
+    image_list = new_docker_image.list_processes()
+    image_list_mock.assert_called_once_with(filters=image_filter)
+    assert image_list == expected_name_list
+
+def test_stop_image():
+  """Verify that we invoke the proper call to stop a docker image."""
+
+  test_image_name = "some_random_running_docker_image"
+
+  mock_container = docker.models.containers.Container()
+  mock_container.stop = mock.MagicMock(return_value=None)
+
+  new_docker_image = docker_image.DockerImage()
+  with mock.patch('docker.models.containers.ContainerCollection.get',
+                  mock.MagicMock(return_value=mock_container)) \
+      as image_get_mock:
+
+    new_docker_image.stop_image(test_image_name)
+
+    image_get_mock.assert_called_once_with(test_image_name)
+    mock_container.stop.assert_called_once()
 
 if __name__ == '__main__':
   raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
In this change we add a context manager to enumerate and stop any lingering docker images from the benchmark.

We also fixed a couple outstanding issues:
1.  in a BUILD file "data" is correctly replaced by "srcs".
2.  fix import statements in the test (for now.  Other files are forthcoming)

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k, @landesherr