### PR TITLE
Add source management and test stubs

### DIFF
--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -8,21 +8,21 @@ package(
 
 py_library(
     name = "job_control",
-    data = [
+    srcs = [
         "job_control_loader.py",
     ],
 )
 
 py_library(
     name = "constants",
-    data = [
+    srcs = [
         "constants.py",
     ],
 )
 
 py_library(
     name = "shell",
-    data = [
+    srcs = [
         "cmd_exec.py",
     ],
 )
@@ -37,3 +37,49 @@ py_test(
         "//api:schema_proto",
     ],
 )
+
+py_library(
+    name = "source_tree",
+    srcs = [
+        "source_tree.py",
+    ],
+    deps = [
+        "//api:schema_proto",
+        ":shell",
+        ":constants",
+    ],
+)
+
+py_library(
+    name = "source_manager",
+    srcs = [
+        "source_manager.py",
+    ],
+    deps = [
+        ":source_tree",
+    ],
+)
+
+py_test(
+  name = "test_source_tree",
+  srcs = [ "test_source_tree.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      ":source_tree",
+      ":shell"
+  ],
+)
+
+py_test(
+  name = "test_source_manager",
+  srcs = [ "test_source_manager.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      ":source_tree",
+      ":source_manager",
+      ":shell"
+  ],
+)
+

--- a/salvo/src/lib/benchmark/base_benchmark.py
+++ b/salvo/src/lib/benchmark/base_benchmark.py
@@ -6,8 +6,8 @@ import os
 import logging
 from typing import List
 
-import src.lib.docker.docker_image as docker_image
-import src.lib.docker.docker_volume as docker_volume
+from src.lib.docker import (docker_image, docker_volume)
+
 import api.control_pb2 as proto_control
 import api.image_pb2 as proto_image
 import api.source_pb2 as proto_source

--- a/salvo/src/lib/benchmark/test_base_benchmark.py
+++ b/salvo/src/lib/benchmark/test_base_benchmark.py
@@ -6,7 +6,7 @@ import copy
 import pytest
 
 import api.env_pb2 as proto_env
-import src.lib.benchmark.base_benchmark as base_benchmark
+from src.lib.benchmark import base_benchmark
 
 def test_environment_variables():
   """Test that the specified environment variables are set for a

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -10,7 +10,8 @@ import api.control_pb2 as proto_control
 import api.image_pb2 as proto_image
 import api.env_pb2 as proto_environ
 import api.source_pb2 as proto_source
-import src.lib.benchmark.fully_dockerized_benchmark as full_docker
+
+from src.lib.benchmark import fully_dockerized_benchmark as full_docker
 from src.lib.benchmark import base_benchmark
 from src.lib.docker import docker_image
 

--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -1,16 +1,21 @@
-"""
-Constants module
-"""
+"""This module defines string constants used in various parts of Salvo"""
 
-"""
-The DOCKER_SOCKET_PATH identifies the unix socket creatd by the docker
-daemon. In its absense any operations interacting with docker will fail.
-"""
+# The DOCKER_SOCKET_PATH identifies the unix socket creatd by the docker
+# daemon. In its absense any operations interacting with docker will fail.
 DOCKER_SOCKET_PATH = '/var/run/docker.sock'
 
-"""
-NIGHTHAWK_EXTERNAL_TEST_DIR is the location within the nighthawk-benchmark container
-where user provided test are mounted. The benchmark discovers all tests in this path,
-in the container, and runs them
-"""
-NIGHTHAWK_EXTERNAL_TEST_DIR = '/usr/local/bin/benchmarks/benchmarks.runfiles/nighthawk/benchmarks/external_tests/'
+# SALVO_TMP is the path where any temporary directories are created when
+# operating locally
+SALVO_TMP = '/tmp/salvo'
+
+# NIGHTHAWK_EXTERNAL_TEST_DIR is the location within the nighthawk-benchmark
+# container where user provided test are mounted. The benchmark discovers all
+# tests in this path, in the container, and executes them
+NIGHTHAWK_EXTERNAL_TEST_DIR = ('/usr/local/bin/benchmarks/benchmarks.runfiles'
+                               '/nighthawk/benchmarks/external_tests/')
+
+# OPT_LLVM and USR_BIN are directory prefixes where we search for the clang
+# compiler used to build the Envoy binary
+OPT_LLVM = '/opt/llvm/bin/'
+USR_BIN = '/usr/bin'
+

--- a/salvo/src/lib/docker/docker_volume.py
+++ b/salvo/src/lib/docker/docker_volume.py
@@ -6,9 +6,9 @@ with docker.
 import json
 import logging
 
-import google.protobuf.json_format as json_format
+from google.protobuf import json_format
+from src.lib import constants
 import api.docker_volume_pb2 as proto_docker_volume
-import src.lib.constants as constants
 
 log = logging.getLogger(__name__)
 

--- a/salvo/src/lib/job_control_loader.py
+++ b/salvo/src/lib/job_control_loader.py
@@ -5,8 +5,8 @@ import json
 import logging
 import yaml
 
+from google.protobuf import json_format
 import api.control_pb2 as proto_control
-import google.protobuf.json_format as json_format
 
 log = logging.getLogger(__name__)
 

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -5,7 +5,7 @@ code
 import logging
 from typing import List
 
-import src.lib.source_tree as source_tree
+from src.lib import source_tree
 import api.source_pb2 as proto_source
 import api.control_pb2 as proto_control
 
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 """The KNOWN_REPOSITORIES map contains the known remote locations for the source
    code needed to build Envoy.
 """
-KNOWN_REPOSITORIES = {'envoy': 'https://github.com/envoyproxy/envoy.git'}
+_KNOWN_REPOSITORIES = {'envoy': 'https://github.com/envoyproxy/envoy.git'}
 
 # In the list of benchmarks to execute, the Baseline image is always
 # the last entry
@@ -89,7 +89,7 @@ class SourceManager(object):
 
     Using the name and tag for the envoy image specified in the control
     document, determine the previous image hash.  Return all discovered
-    hashes in a dictionary.
+    hashes.
 
     If secondary images or secondary hashes are present, we will use these
     images for benchmarking and will not do any hash deduction.
@@ -120,11 +120,14 @@ class SourceManager(object):
     """
     return []
 
-  def get_source_repository(self, source_id) -> proto_source.SourceRepository:
+def get_source_repository(self, \
+    source_id: proto_source.SourceRepository.SourceIdentity) \
+    -> proto_source.SourceRepository:
     """Find and return the source repository object with the specified id
 
     Args:
-      source_id: The identity of the source object we seek
+      source_id: The identity of the source object we seek (eg.
+        SRCID_NIGHTHAWK or SRCID_ENVOY)
 
     Return:
       a Source repository matching the specified source_id

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -1,0 +1,135 @@
+"""
+This module abstracts the higher level functions of managing source
+code
+"""
+import logging
+from typing import List
+
+import src.lib.source_tree as source_tree
+import api.source_pb2 as proto_source
+import api.control_pb2 as proto_control
+
+log = logging.getLogger(__name__)
+
+"""The KNOWN_REPOSITORIES map contains the known remote locations for the source
+   code needed to build Envoy.
+"""
+KNOWN_REPOSITORIES = {'envoy': 'https://github.com/envoyproxy/envoy.git'}
+
+# In the list of benchmarks to execute, the Baseline image is always
+# the last entry
+BASELINE = -1
+
+class SourceManagerError(Exception):
+  """Raised when an unrecoverable error is encountered while working with
+     a source tree.
+  """
+
+class SourceManager(object):
+  """This class is a manager for SourceTree objects.
+
+  SourceTree objects abstract the git operations needed to manipulate source
+  code checked out on disk.
+  """
+
+  def __init__(self, control: proto_control.JobControl) -> None:
+    """Set the job control containing the source locations.
+
+    Args:
+      control: The JobControl object defining the parameters of the benchmark
+    """
+    self._control = control
+    self._builder = None
+
+  def determine_envoy_hashes_from_source(self) -> List[str]:
+    """Determine the previous commit hash or tag from the baseline envoy image.
+
+    Returns:
+      a List containing current and previous commit hashes needed to identify
+        the envoy image for benchmarking.
+
+    Raises:
+      a SourceManagerError if we are unable to determine the prior commit
+        or tag
+    """
+    pass
+
+  def find_all_images_from_specified_tags(self) -> List[str]:
+    """Find all images required for benchmarking from the images specified
+       in the job control object.
+
+    Returns:
+      a list of commit hashes or tags needed to identify docker images
+        needed for the benchmark execution.
+
+    Raises:
+      SourceManagerError: if no images are specified in the control
+        document.  We require the nighthawk images to be specified at a
+        minimum.  We will not build those from source yet.
+    """
+    pass
+
+  def find_all_images_from_specified_sources(self) -> List[str]:
+    """Find all images required for benchmarking from the source and hashes
+       specified in the job control object.
+
+    Returns:
+      a list of commit hashes or tags needed to identify docker images
+        needed for the benchmark execution.
+
+    Raises:
+      SourceManagerError: if no images are specified in the control
+        document. We require the nighthawk images to be specified at a
+        minimum.  We will not build those from source yet.
+    """
+    pass
+
+  def get_envoy_hashes_for_benchmark(self) -> List[str]:
+    """Determine the hashes for the baseline and previous Envoy Image.
+
+    Using the name and tag for the envoy image specified in the control
+    document, determine the previous image hash.  Return all discovered
+    hashes in a dictionary.
+
+    If secondary images or secondary hashes are present, we will use these
+    images for benchmarking and will not do any hash deduction.
+
+    Returns:
+      A List of commit hashes or tags that identify the envoy image for
+       the baseline benchmark, and the previous envoy image the results
+       are compared against
+    """
+    pass
+
+  def get_image_hashes_from_disk_source(
+      self, disk_source_tree: source_tree.SourceTree,
+      commit_hash: str) -> List[str]:
+    """Determine the previous hash to the specified commit.
+
+    Args:
+      disk_source_tree: A SourceTree object managing the source on disk
+      commit_hash: a string indicating the commit hash from which we
+        determine its predecessor
+
+    Returns:
+      a List of commit hashes discovered.
+
+    Raises:
+      SourceManagerError: if we are not able to deterimine hashes prior to
+        the identified commit
+    """
+    pass
+
+  def get_source_repository(self, source_id) -> proto_source.SourceRepository:
+    """Find and return the source repository object with the specified id
+
+    Args:
+      source_id: The identity of the source object we seek
+
+    Return:
+      a Source repository matching the specified source_id
+
+    Raises:
+      SourceManagerError: If no source exists matching the specified source_id
+    """
+    pass

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -52,7 +52,7 @@ class SourceManager(object):
       a SourceManagerError if we are unable to determine the prior commit
         or tag
     """
-    pass
+    return []
 
   def find_all_images_from_specified_tags(self) -> List[str]:
     """Find all images required for benchmarking from the images specified
@@ -67,7 +67,7 @@ class SourceManager(object):
         document.  We require the nighthawk images to be specified at a
         minimum.  We will not build those from source yet.
     """
-    pass
+    return []
 
   def find_all_images_from_specified_sources(self) -> List[str]:
     """Find all images required for benchmarking from the source and hashes
@@ -82,7 +82,7 @@ class SourceManager(object):
         document. We require the nighthawk images to be specified at a
         minimum.  We will not build those from source yet.
     """
-    pass
+    return []
 
   def get_envoy_hashes_for_benchmark(self) -> List[str]:
     """Determine the hashes for the baseline and previous Envoy Image.
@@ -99,7 +99,7 @@ class SourceManager(object):
        the baseline benchmark, and the previous envoy image the results
        are compared against
     """
-    pass
+    return []
 
   def get_image_hashes_from_disk_source(
       self, disk_source_tree: source_tree.SourceTree,
@@ -118,7 +118,7 @@ class SourceManager(object):
       SourceManagerError: if we are not able to deterimine hashes prior to
         the identified commit
     """
-    pass
+    return []
 
   def get_source_repository(self, source_id) -> proto_source.SourceRepository:
     """Find and return the source repository object with the specified id
@@ -132,4 +132,4 @@ class SourceManager(object):
     Raises:
       SourceManagerError: If no source exists matching the specified source_id
     """
-    pass
+    return proto_source.SourceRepository()

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from subprocess import CalledProcessError
+from typing import List
 
 import src.lib.cmd_exec as cmd_exec
 import src.lib.constants as constants
@@ -37,7 +38,9 @@ class SourceTree(object):
     """Create temporary directories for building and working
         with a source tree.
     """
-    self._tempdir = fileops.get_random_dir(constants.SALVO_TMP)
+
+    # Get the temporary directory from fileops module
+    self._tempdir = None
 
     self._source_repo = source_repo
     self._source_url = source_repo.source_url
@@ -102,7 +105,7 @@ class SourceTree(object):
         HEAD and the local HEAD.  This diff is applied to the source in the
         remote context.
     """
-    pass
+    return ''
 
   def get_directory(self) -> str:
     """Return the full path where the code has been checked out.
@@ -110,7 +113,7 @@ class SourceTree(object):
     Returns:
       a string containing the disk path to the source.
     """
-    pass
+    return ''
 
   def pull(self) -> bool:
     """Retrieve the code from the repository.
@@ -121,7 +124,7 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the operation was successful
     """
-    pass
+    return False
 
   def checkout_commit_hash(self) -> bool:
     """Checks out the specified commit hash in the source tree
@@ -129,7 +132,7 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the operation was successful
     """
-    pass
+    return False
 
   def get_head_hash(self) -> str:
     """Retrieve the hash for the HEAD commit.
@@ -138,7 +141,7 @@ class SourceTree(object):
       a string containing the hash corresponding to commit at the HEAD of the
         tree.
     """
-    pass
+    return ''
 
   def get_previous_commit_hash(self, current_commit: str,
                                revisions: int = 2) -> str:
@@ -152,7 +155,7 @@ class SourceTree(object):
     Returns:
       a string with the discovered commit hash
     """
-    pass
+    return ''
 
   def get_revs_behind_parent_branch(self) -> int:
     """Get the number of commits behind the parent branch.
@@ -164,7 +167,7 @@ class SourceTree(object):
       an integer with the number of commits the local source lags
        behind the parent branch
     """
-    pass
+    return 0
 
   def is_up_to_date(self) -> bool:
     """Determine whether the source tree is up to date.
@@ -172,15 +175,15 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the tree is up to date.
     """
-    pass
+    return False
 
-  def list_tags(self) -> list:
+  def list_tags(self) -> List[str]:
     """Enumerate the repository tags and return them in a list.
 
     Returns:
       a list of tags from the commits
     """
-    pass
+    return []
 
   def get_previous_tag(self, current_tag: str, revisions: int = 1) -> str:
     """Identify a tag a number of revisions behind the current tag.
@@ -201,4 +204,4 @@ class SourceTree(object):
         we expect
 
     """
-    pass
+    return ''

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -3,18 +3,19 @@
 import logging
 import os
 import re
-from subprocess import CalledProcessError
+import subprocess
 from typing import List
 
-import src.lib.cmd_exec as cmd_exec
-import src.lib.constants as constants
+from src.lib import (cmd_exec, constants)
 
 import api.source_pb2 as proto_source
 
 log = logging.getLogger(__name__)
 
-
-TAG_REGEX = r'^v\d\.\d+\.\d+'
+# _TAG_REGEX matches strings of the format "v1.16.0".  We use this to
+# determine whether a user specified a commit hash or a release tag
+# for a given docker image
+_TAG_REGEX = r'^v\d\.\d+\.\d+'
 
 class SourceTreeException(Exception):
   """Raised if we encounter a condition from which we cannot recover, when
@@ -23,7 +24,7 @@ class SourceTreeException(Exception):
 
 def is_tag(image_tag: str) -> bool:
   """Determine whether a an image tag is a commit hash or a version tag."""
-  match = re.match(TAG_REGEX, image_tag)
+  match = re.match(_TAG_REGEX, image_tag)
   return match is not None
 
 
@@ -88,7 +89,9 @@ class SourceTree(object):
     if self._source_path and not self._source_url:
       return True
 
-    return False
+    raise SourceTreeException(
+        "Insufficient information in source definition for it to be usable")
+
 
   def get_source_identity(self) -> \
       proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -1,0 +1,204 @@
+"""This module contains methods for managing a source tree"""
+
+import logging
+import os
+import re
+from subprocess import CalledProcessError
+
+import src.lib.cmd_exec as cmd_exec
+import src.lib.constants as constants
+
+import api.source_pb2 as proto_source
+
+log = logging.getLogger(__name__)
+
+
+TAG_REGEX = r'^v\d\.\d+\.\d+'
+
+class SourceTreeException(Exception):
+  """Raised if we encounter a condition from which we cannot recover, when
+     manipulating SourceTree objects.
+  """
+
+def is_tag(image_tag: str) -> bool:
+  """Determine whether a an image tag is a commit hash or a version tag."""
+  match = re.match(TAG_REGEX, image_tag)
+  return match is not None
+
+
+class SourceTree(object):
+  """Abstracts the manipulation of souce locations on disk.
+
+  This class encapsulates the git logic needed to determine the endpoints
+  of the benchmark.
+  """
+
+  def __init__(self, source_repo: proto_source.SourceRepository) -> None:
+    """Create temporary directories for building and working
+        with a source tree.
+    """
+    self._tempdir = fileops.get_random_dir(constants.SALVO_TMP)
+
+    self._source_repo = source_repo
+    self._source_url = source_repo.source_url
+    self._branch = source_repo.branch
+    self._commit_hash = source_repo.commit_hash
+    self._source_path = source_repo.source_path
+
+  def __repr__(self) -> str:
+    """Return a string representation of this class."""
+    return '{name}: Origin: [{origin}] Branch: [{branch}] Hash: [{hash}] \
+      Workdir [{dir}]'.format(
+          name=type(self).__name__,
+          origin=self._source_url,
+          branch=self._branch,
+          hash=self._commit_hash,
+          dir=self._source_path)
+
+  def _validate(self) -> bool:
+    """Verify that we have enough data to work with the source tree.
+
+    Returns:
+      a bool indicating that we have a source path on disk or a url from
+        which to pull the source.
+
+    Raises:
+      SourceTreeException: if no path or url is specified for the class to
+        operate.
+    """
+
+    if all([not self._source_path, not self._source_url]):
+      raise SourceTreeException(
+          "No origin is defined or can be deduced from the path")
+
+    # We must have either a path or an origin url defined
+    if not self._source_path and self._source_url:
+      log.debug(f"No source path.  Using {self._tempdir} for future clone")
+
+      if not os.path.exists(self._tempdir):
+        os.mkdir(self._tempdir)
+
+      self._source_path = self._tempdir
+      return True
+
+    # We have a working directory on disk and can deduce the origin from it
+    if self._source_path and not self._source_url:
+      return True
+
+    return False
+
+  def get_source_identity(self) -> \
+      proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
+    """Returns the identity of the source tree being managed."""
+    return self._source_repo.identity
+
+  def get_origin(self) -> str:
+    """Detect the origin url from where the code is fetched.
+
+    Returns:
+      A string showing the origin url for the source tree.  This needed most
+        for remote execution where we do not ship the entire source tree
+        remotely.  We will attempt to generate a patch between the origin
+        HEAD and the local HEAD.  This diff is applied to the source in the
+        remote context.
+    """
+    pass
+
+  def get_directory(self) -> str:
+    """Return the full path where the code has been checked out.
+
+    Returns:
+      a string containing the disk path to the source.
+    """
+    pass
+
+  def pull(self) -> bool:
+    """Retrieve the code from the repository.
+
+    Uses git to clone the source into a working directory that has read/write
+    permissions by salvo
+
+    Returns:
+      a boolean indicating whether the operation was successful
+    """
+    pass
+
+  def checkout_commit_hash(self) -> bool:
+    """Checks out the specified commit hash in the source tree
+
+    Returns:
+      a boolean indicating whether the operation was successful
+    """
+    pass
+
+  def get_head_hash(self) -> str:
+    """Retrieve the hash for the HEAD commit.
+
+    Returns:
+      a string containing the hash corresponding to commit at the HEAD of the
+        tree.
+    """
+    pass
+
+  def get_previous_commit_hash(self, current_commit: str,
+                               revisions: int = 2) -> str:
+    """Return the specified number of commits behind the current commit hash.
+
+    Args:
+      current_commit: The current hash from which we are starting the search
+      revisions: The number of commits in the tree that we skip over, starting
+        from the current_commit
+
+    Returns:
+      a string with the discovered commit hash
+    """
+    pass
+
+  def get_revs_behind_parent_branch(self) -> int:
+    """Get the number of commits behind the parent branch.
+
+    Determine how many commits the current branch on disk is behind the
+    parent branch.  If we are up to date, return zero
+
+    Returns:
+      an integer with the number of commits the local source lags
+       behind the parent branch
+    """
+    pass
+
+  def is_up_to_date(self) -> bool:
+    """Determine whether the source tree is up to date.
+
+    Returns:
+      a boolean indicating whether the tree is up to date.
+    """
+    pass
+
+  def list_tags(self) -> list:
+    """Enumerate the repository tags and return them in a list.
+
+    Returns:
+      a list of tags from the commits
+    """
+    pass
+
+  def get_previous_tag(self, current_tag: str, revisions: int = 1) -> str:
+    """Identify a tag a number of revisions behind the current tag.
+
+    Find the current tag among the ones retrieed from the repository and return
+    the previous tag
+
+    Args:
+      current_tag: the tag for the baseline revision of the source
+      revisions: The number of tags in the tree that we skip over, starting from
+        the current_tag
+
+    Returns:
+      the sought after tag
+
+    Raises:
+      SourceTreeException: if the specified tag does not match the tag format
+        we expect
+
+    """
+    pass

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -6,9 +6,9 @@ import json
 import tempfile
 import pytest
 
-import google.protobuf.json_format as json_format
-import src.lib.constants as constants
-import src.lib.job_control_loader as job_ctrl
+from google.protobuf import json_format
+from src.lib import constants
+from src.lib import job_control_loader as job_ctrl
 
 import api.control_pb2 as proto_control
 import api.source_pb2 as proto_source

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -1,0 +1,63 @@
+"""
+Test source management operations needed for executing benchmarks
+"""
+import logging
+import shlex
+import pytest
+import unittest.mock as mock
+
+import src.lib.source_manager as source_manager
+import src.lib.source_tree as source_tree
+import api.control_pb2 as proto_control
+
+logging.basicConfig(level=logging.DEBUG)
+
+log = logging.getLogger(__name__)
+
+def _run_command_side_effect(*args):
+  """Adjust the check_output output so that we can respond differently to
+  input arguments.
+
+  Args:
+    args: the list of arguments received by the mocked functin
+  """
+  pass
+
+def _generate_default_benchmark_images(job_control):
+  """Generate a default image configuration for the job control object."""
+
+  image_config = job_control.images
+  image_config.reuse_nh_images = True
+  image_config.nighthawk_benchmark_image = \
+    "envoyproxy/nighthawk-benchmark-dev:latest"
+  image_config.nighthawk_binary_image = \
+    "envoyproxy/nighthawk-dev:latest"
+
+  return image_config
+
+@mock.patch("src.lib.cmd_exec.run_command")
+def test_get_envoy_images_for_benchmark(mock_run_command):
+  """Verify that we can determine the current and previous image
+     tags from a minimal job control object.
+  """
+  pass
+
+def _run_command_side_effect_for_disk_files(*args):
+  """Adjust the check_call output so that we can respond differently to
+     input arguments.
+
+  Args:
+    args: the list of arguments received by the mocked function
+  """
+  pass
+
+@mock.patch("src.lib.cmd_exec.run_command")
+def test_previous_hash_with_disk_files(mock_run_command):
+  """
+  Verify that we can determine Envoy images from source locations
+  """
+  pass
+
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -4,10 +4,10 @@ Test source management operations needed for executing benchmarks
 import logging
 import shlex
 import pytest
-import unittest.mock as mock
+from unittest import mock
 
-import src.lib.source_manager as source_manager
-import src.lib.source_tree as source_tree
+from src.lib import (source_manager, source_tree)
+
 import api.control_pb2 as proto_control
 
 logging.basicConfig(level=logging.DEBUG)

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -1,0 +1,143 @@
+"""
+Test source_tree operations needed for executing benchmarks
+"""
+from unittest import mock
+import pytest
+import logging
+import subprocess
+
+from src.lib import (cmd_exec, source_tree)
+import api.source_pb2 as proto_source
+
+log = logging.getLogger(__name__)
+
+def test_source_tree_object():
+  """Verify that we throw an exception if not all required data is present."""
+  pass
+
+def test_git_with_origin():
+  """Verify that at a minimum, we can work with a remote origin url
+     specified.
+  """
+  pass
+
+def test_source_tree_with_local_workdir():
+  """Verify that we can work with a source location on disk."""
+  pass
+
+def test_get_origin_ssh():
+  """Verify that we can determine the origin for a local repository.
+
+  In this instance the repo was cloned via ssh.
+  """
+  pass
+
+def test_get_origin_https():
+  """Verify that we can determine the origin for a local repository.
+
+  In this instance the repo was cloned via https
+  """
+  pass
+
+def _generate_source_tree_from_origin(origin):
+  """Build a source tree from a remote url."""
+  pass
+
+def mock_run_command_side_effect(*args):
+  """Mock run_command side effect for checkout operation."""
+  pass
+
+@mock.patch("src.lib.cmd_exec.run_command")
+def test_source_tree_pull(mock_run_command):
+  """Verify that we can clone a repository ensuring that the process completed
+     without errors.
+  """
+  pass
+
+def mock_run_command_side_effect_failure(*args):
+  """Mock run_command side effect for checkout operation."""
+  pass
+
+@mock.patch("src.lib.cmd_exec.run_command")
+def test_source_tree_pull_failure(mock_run_command):
+  """Verify that we can clone a repository and detect an incomplete
+     operation.
+  """
+  pass
+
+def test_retrieve_head_hash():
+  """Verify that we can determine the hash for the head commit."""
+  pass
+
+def _check_output_side_effect(*args):
+  """Respond to the mocked function call with the correct output.
+
+  Args:
+    args: the arguments supplied to the mock.  The first argument is the
+      command being executed.
+
+    kwargs: the keyword arguments supplied to the mock. In this case
+      the 'cwd' (working directory) is the one keyword that should always
+      be present
+  """
+  pass
+
+@mock.patch('src.lib.cmd_exec.run_command')
+def test_get_previous_commit(mock_check_output):
+  """Verify that we can identify one commit prior to a specified hash. """
+  pass
+
+def _check_output_side_effect_fail(*args):
+  """Respond to the mocked function call with the correct output.
+
+  Args:
+    args: the arguments supplied to the mock.  The first argument is the
+      command being executed.
+  """
+  pass
+
+@mock.patch('src.lib.cmd_exec.run_command')
+def test_get_previous_commit_fail(mock_check_output):
+  """Verify that we can identify a failure when attempting to manage commit
+     hashes.
+  """
+  pass
+
+def test_parent_branch_ahead():
+  """Verify that we can determine how many commits beind the local source tree
+     lags behind the remote repository.
+  """
+  pass
+
+def test_parent_branch_up_to_date():
+  """Verify that we can determine how many commits beind the local source tree
+     lags behind the remote repository.
+  """
+  pass
+
+def test_branch_up_to_date():
+  """Verify that we can determine a source tree is up to date."""
+  pass
+
+def test_list_tags():
+  """Verify that we can list tags from a repository."""
+  pass
+
+def test_is_tag():
+  """Verify that we can detect a hash and a git tag."""
+  pass
+
+def test_get_previous_tag():
+  """Verify that we can identify the previous tag for a given release."""
+  pass
+
+def test_get_previous_n_tag():
+  """Verify that we can identify the previous tag for a given release."""
+  pass
+
+def test_source_tree_with_disk_files():
+  """Verify that we can get hash data from a source tree on disk."""
+  pass
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
Happy New Year! :)

Changes in this PR include:

- Stub out the source tree and source manager modules and their tests.
- Fix a few instances in a BUILD where `srcs` are labeled as `data`
- Fix the comments in `constants.py` to comply with pylint

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @landesherr, @mum4k 