### PR TITLE
Add source_tree implementation and tests

### DIFF
--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -47,6 +47,7 @@ py_library(
         "//api:schema_proto",
         ":shell",
         ":constants",
+        "//src/lib/common:fileops"
     ],
 )
 

--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -47,7 +47,7 @@ py_library(
         "//api:schema_proto",
         ":shell",
         ":constants",
-        "//src/lib/common:fileops"
+        "//src/lib/common:file_ops"
     ],
 )
 

--- a/salvo/src/lib/common/BUILD
+++ b/salvo/src/lib/common/BUILD
@@ -1,0 +1,12 @@
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(
+  default_visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "fileops",
+    data = [
+        "fileops.py",
+    ],
+)

--- a/salvo/src/lib/common/BUILD
+++ b/salvo/src/lib/common/BUILD
@@ -10,3 +10,11 @@ py_library(
         "file_ops.py",
     ],
 )
+py_test(
+    name = "test_file_ops",
+    srcs = ["test_file_ops.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":file_ops",
+    ],
+)

--- a/salvo/src/lib/common/BUILD
+++ b/salvo/src/lib/common/BUILD
@@ -5,8 +5,8 @@ package(
 )
 
 py_library(
-    name = "fileops",
+    name = "file_ops",
     data = [
-        "fileops.py",
+        "file_ops.py",
     ],
 )

--- a/salvo/src/lib/common/file_ops.py
+++ b/salvo/src/lib/common/file_ops.py
@@ -25,8 +25,7 @@ def open_json(path: str, mode: str = 'r') -> dict:
 
 
 def open_yaml(path: str, mode: str = 'r') -> dict:
-  """Open a json file and return its contents as a dictionary
-
+  """Open a yaml file and return its contents as a dictionary 
   Args:
     path: the full path to the YAML file
     mode: the mode with which we open the file.  The mode defaults

--- a/salvo/src/lib/common/fileops.py
+++ b/salvo/src/lib/common/fileops.py
@@ -1,0 +1,68 @@
+"""
+Module to abstract a few common file operations used in the framework
+"""
+import json
+import random
+import shutil
+import yaml
+import glob
+import os
+import tempfile
+
+
+def open_json(path: str, mode: str = 'r') -> dict:
+  """Open a json file and return its contents as a dictionary
+
+  Args:
+    path: the full path to the JSON file
+    mode: the mode with which we open the file.  The mode defaults
+      to read only and is an optional argument.
+  """
+  data = {}
+  with open(path, mode) as json_file:
+    data = json.loads(json_file.read())
+  return data
+
+
+def open_yaml(path: str, mode: str = 'r') -> dict:
+  """Open a json file and return its contents as a dictionary
+
+  Args:
+    path: the full path to the YAML file
+    mode: the mode with which we open the file.  The mode defaults
+      to read only and is an optional argument.
+  """
+  data = {}
+  with open(path, mode) as yaml_file:
+    data = yaml.load(yaml_file)
+  return data
+
+
+def delete_directory(path: str) -> None:
+  """Delete a directory and its contents.
+
+  Args:
+    path: The directory to be deleted
+  """
+  shutil.rmtree(path)
+
+
+def get_random_dir(path: str) -> str:
+  """Get a random named directory.
+
+  The caller must re-create the path received if the value
+  is used as-is.
+
+  Args:
+    path: The location where the temporary directory is to be
+     created
+
+  Returns:
+    The full pathname of the temporary directory.
+  """
+
+  if not os.path.exists(path):
+    os.mkdir(path)
+
+  temp_dir = tempfile.TemporaryDirectory(dir=path)
+  return temp_dir.name

--- a/salvo/src/lib/common/test_file_ops.py
+++ b/salvo/src/lib/common/test_file_ops.py
@@ -13,7 +13,7 @@ from src.lib.common import file_ops
 from unittest import mock
 
 
-_test_json = """
+_TEST_JSON = """
 {
   "key" : "this is my json file",
   "key2" : "there are many like it",
@@ -23,7 +23,7 @@ _test_json = """
 }
 """
 
-_test_yaml = """
+_TEST_YAML = """
 key: this is my json file
 key2: there are many like it
 key3:
@@ -42,7 +42,7 @@ def _validate_test_data(file_data):
 def test_open_json():
   with tempfile.NamedTemporaryFile() as temp_json:
     with open(temp_json.name, 'w') as temp_data:
-      temp_data.write(_test_json)
+      temp_data.write(_TEST_JSON)
 
     json_data = file_ops.open_json(temp_json.name)
     _validate_test_data(json_data)
@@ -50,7 +50,7 @@ def test_open_json():
 def test_open_yaml():
   with tempfile.NamedTemporaryFile() as temp_yaml:
     with open(temp_yaml.name, 'w') as temp_data:
-      temp_data.write(_test_yaml)
+      temp_data.write(_TEST_YAML)
 
     yaml_data = file_ops.open_yaml(temp_yaml.name)
     _validate_test_data(yaml_data)
@@ -58,7 +58,7 @@ def test_open_yaml():
 def test_open_yaml_as_json():
   with tempfile.NamedTemporaryFile() as temp_json:
     with open(temp_json.name, 'w') as temp_data:
-      temp_data.write(_test_yaml)
+      temp_data.write(_TEST_YAML)
 
     with pytest.raises(json.decoder.JSONDecodeError) as decode_error:
       json_data = file_ops.open_json(temp_json.name)
@@ -68,7 +68,7 @@ def test_open_yaml_as_json():
 def test_open_json_as_yaml():
   with tempfile.NamedTemporaryFile() as temp_yaml:
     with open(temp_yaml.name, 'w') as temp_data:
-      temp_data.write(_test_json)
+      temp_data.write(_TEST_JSON)
 
     yaml_data = file_ops.open_yaml(temp_yaml.name)
     _validate_test_data(yaml_data)

--- a/salvo/src/lib/common/test_file_ops.py
+++ b/salvo/src/lib/common/test_file_ops.py
@@ -1,0 +1,89 @@
+
+"""
+Test source_tree operations needed for executing benchmarks
+"""
+import pytest
+
+import os
+import json
+import tempfile
+
+from src.lib.common import file_ops
+
+from unittest import mock
+
+
+_test_json = """
+{
+  "key" : "this is my json file",
+  "key2" : "there are many like it",
+  "key3" : [
+    "but", "this", "one", "is", "mine"
+  ]
+}
+"""
+
+_test_yaml = """
+key: this is my json file
+key2: there are many like it
+key3:
+  - but
+  - this
+  - one
+  - is
+  - mine
+"""
+
+def _validate_test_data(file_data):
+  assert file_data
+  assert all(map(lambda key: key in file_data, ["key", "key2", "key3"]))
+  assert file_data['key3'] == [ 'but', 'this', 'one', 'is', 'mine' ]
+
+def test_open_json():
+  with tempfile.NamedTemporaryFile() as temp_json:
+    with open(temp_json.name, 'w') as temp_data:
+      temp_data.write(_test_json)
+
+    json_data = file_ops.open_json(temp_json.name)
+    _validate_test_data(json_data)
+
+def test_open_yaml():
+  with tempfile.NamedTemporaryFile() as temp_yaml:
+    with open(temp_yaml.name, 'w') as temp_data:
+      temp_data.write(_test_yaml)
+
+    yaml_data = file_ops.open_yaml(temp_yaml.name)
+    _validate_test_data(yaml_data)
+
+def test_open_yaml_as_json():
+  with tempfile.NamedTemporaryFile() as temp_json:
+    with open(temp_json.name, 'w') as temp_data:
+      temp_data.write(_test_yaml)
+
+    with pytest.raises(json.decoder.JSONDecodeError) as decode_error:
+      json_data = file_ops.open_json(temp_json.name)
+
+    assert 'Expecting value' in str(decode_error.value)
+
+def test_open_json_as_yaml():
+  with tempfile.NamedTemporaryFile() as temp_yaml:
+    with open(temp_yaml.name, 'w') as temp_data:
+      temp_data.write(_test_json)
+
+    yaml_data = file_ops.open_yaml(temp_yaml.name)
+    _validate_test_data(yaml_data)
+
+def test_delete_directory():
+  with mock.patch('shutil.rmtree') as magic_mock:
+    file_ops.delete_directory('this_is_my_directory')
+
+  magic_mock.assert_called_once_with('this_is_my_directory')
+
+def test_get_random_dir():
+  temp_path = file_ops.get_random_dir('my_test_path')
+  assert temp_path
+  parent_dir = os.path.dirname(temp_path)
+  assert parent_dir == 'my_test_path'
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -6,7 +6,7 @@ import subprocess
 from typing import List
 
 from src.lib import (cmd_exec, constants)
-from src.lib.common import fileops
+from src.lib.common import file_ops
 
 import api.source_pb2 as proto_source
 
@@ -16,6 +16,12 @@ log = logging.getLogger(__name__)
 # determine whether a user specified a commit hash or a release tag
 # for a given docker image
 _TAG_REGEX = r'^v\d\.\d+\.\d+'
+
+# _GIT_ORIGIN_REGEX matches the fetch urls returned in `git origin -v`
+# For example, from
+# origin        https://github.com/envoyproxy/envoy.git (fetch)"
+# we get https://github.com/envoyproxy/envoy.git in an enumerated group
+_GIT_ORIGIN_REGEX = r'^origin\s*([\w:@\.\/-]+)\s\(fetch\)$'
 
 class SourceTreeError(Exception):
   """Raised if we encounter a condition from which we cannot recover, when
@@ -48,24 +54,23 @@ class SourceTree(object):
     if not home_dir.startswith(constants.SALVO_TMP):
       home_dir = constants.SALVO_TMP
 
-    self._tempdir = fileops.get_random_dir(home_dir)
-
+    self._tempdir = file_ops.get_random_dir(home_dir)
     self._source_repo = source_repo
-    self._source_url = self._source_repo.source_url
-    self._branch = self._source_repo.branch
-    self._commit_hash = self._source_repo.commit_hash
-    self._source_path = self._source_repo.source_path
 
   def __repr__(self) -> str:
     """Return a string representation of this class."""
 
     result = f"{type(self).__name__}: "
-    result += f"Origin: [{self._source_url}] "
-    result += f"Branch: [{self._branch}] "
-    result += f"Hash: [{self._commit_hash}] "
-    result += f"Workdir: [{self._source_path}]"
+    result += f"Origin: [{self._source_repo.source_url}] "
+    result += f"Branch: [{self._source_repo.branch}] "
+    result += f"Hash: [{self._source_repo.commit_hash}] "
+    result += f"Workdir: [{self._source_repo.source_path}]"
 
     return result
+
+  def get_identity(self) -> proto_source.SourceRepository.SourceIdentity:
+    """Return the identity of the source tree being managed."""
+    return self._source_repo.identity
 
   def _validate(self) -> bool:
     """Verify that we have enough data to work with the source tree.
@@ -82,31 +87,31 @@ class SourceTree(object):
     # We have neither a source url nor source on disk.
     # - This is a non starter and we cannot operate further. We don't know where
     #   to get the source for building anything
-    if all([not self._source_path, not self._source_url]):
+    if all([not self._source_repo.source_path,
+            not self._source_repo.source_url]):
       raise SourceTreeError(
           "No origin is defined or can be deduced from the path")
 
     # We have a source url and no source on disk -> good.
     # - We can clone the url to a temporary disk location and work in that
     #   directory
-    if not self._source_path and self._source_url:
-      log.debug(f"No source path. Using {self._tempdir} for future clone")
+    if not self._source_repo.source_path and self._source_repo.source_url:
+      log.debug(f"No source path in control object. Using {self._tempdir}")
 
       if not os.path.exists(self._tempdir):
         os.mkdir(self._tempdir)
 
-      self._source_path = self._tempdir
       return True
 
     # We have a source url and a source on disk -> good.
     # - This means we have pulled/cloned the source, or the source is to be
     #   copied from the specified directory
-    if self._source_path and self._source_url:
+    if self._source_repo.source_path and self._source_repo.source_url:
       return True
 
     # We have a source on disk and no source url -> good
     # - We can copy the source tree and determine what we need from it.
-    if self._source_path and not self._source_url:
+    if self._source_repo.source_path and not self._source_repo.source_url:
       return True
 
     log.debug(f"Validation failed for source tree: {self}")
@@ -126,22 +131,28 @@ class SourceTree(object):
     valid = self._validate()
     log.debug(f"Valid: {valid} for object: {self}")
 
-    origin_url = self._source_url
+    origin_url = self._source_repo.source_url
+    output_directory = self.get_source_directory()
 
     cmd = "git remote -v"
     if not origin_url:
-      cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+      cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
       output = cmd_exec.run_command(cmd, cmd_params)
       for line in output.split('\n'):
-        match = re.match(r'^origin\s*([\w:@\.\/-]+)\s\(fetch\)$', line)
+        match = re.match(_GIT_ORIGIN_REGEX, line)
         if match:
           origin_url = match.group(1)
-          self._source_url = origin_url
+          self._source_repo.source_url = origin_url
           break
+
+    if not origin_url:
+      raise SourceTreeError(
+          f"Unable to determine the origin url from {output_directory}"
+      )
 
     return origin_url
 
-  def get_directory(self) -> str:
+  def get_source_directory(self) -> str:
     """Return the full path where the code has been checked out.
 
     Returns:
@@ -149,7 +160,8 @@ class SourceTree(object):
     """
     self._validate()
 
-    return self._source_path
+    return  self._source_repo.source_path \
+                 if self._source_repo.source_path else self._tempdir
 
   def pull(self) -> bool:
     """Retrieve the code from the repository.
@@ -161,10 +173,11 @@ class SourceTree(object):
       a boolean indicating whether the operation was successful
     """
 
+    self._validate()
+
     source_name = proto_source.SourceRepository.SourceIdentity.Name(
         self._source_repo.identity)
-    log.debug(f"Pulling [{source_name}] from origin: [{self._source_url}]")
-    self._validate()
+    log.debug(f"Pulling [{source_name}] from origin: [{self._source_repo.source_url}]")
 
     try:
       if self.is_up_to_date():
@@ -172,26 +185,19 @@ class SourceTree(object):
     except subprocess.CalledProcessError:
       log.info("Source likely does not exist on disk")
 
-    if not self._source_url:
-      self._source_url = self.get_origin()
+    if not self._source_repo.source_url:
+      self._source_repo.source_url = self.get_origin()
+
+    output_dir = self.get_source_directory()
 
     # Clone into the working directory
-    cmd = "git clone {origin} .".format(origin=self._source_url)
-    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    cmd = "git clone {origin} .".format(origin=self._source_repo.source_url)
+    cmd_params = cmd_exec.CommandParameters(cwd=output_dir)
     output = cmd_exec.run_command(cmd, cmd_params)
     expected = 'Cloning into \'.\''
 
-    success = expected in output
+    return expected in output
 
-    # Since this is a reference to the source in the job control, we should
-    # update the path to the cloned source to avoid a second clone of the
-    # repository.
-    if success and not self._source_repo.source_path:
-      self._source_path = self._tempdir
-      self._source_repo.source_path = self._tempdir
-      log.debug(f"Updated the source path to {self._source_repo.source_path}")
-
-    return success
 
   def checkout_commit_hash(self) -> bool:
     """Checks out the specified commit hash in the source tree
@@ -210,14 +216,15 @@ class SourceTree(object):
       log.debug("No local source path exists.  Cloning repo for hash discovery")
       self.pull()
 
-    if self._commit_hash:
-      cmd = "git checkout {hash}".format(hash=self._commit_hash)
-      cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    if self._source_repo.commit_hash:
+      output_directory = self.get_source_directory()
+      cmd = "git checkout {hash}".format(hash=self._source_repo.commit_hash)
+      cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
       output = cmd_exec.run_command(cmd, cmd_params)
 
       # HEAD is now at <8 chars of hash>
       expected = "HEAD is now at {commit_hash}".format(
-          commit_hash=self._commit_hash[:8])
+          commit_hash=self._source_repo.commit_hash[:8])
       log.debug(f"Checkout output: {output}")
 
       checkout_success = expected in output
@@ -236,7 +243,8 @@ class SourceTree(object):
     cmd = ("git rev-list --no-merges --committer='GitHub <noreply@github.com>' "
            "--max-count=1 HEAD")
 
-    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    output_directory = self.get_source_directory()
+    cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
     return cmd_exec.run_command(cmd, cmd_params)
 
   def get_previous_commit_hash(self, current_commit: str,
@@ -250,7 +258,12 @@ class SourceTree(object):
 
     Returns:
       a string with the discovered commit hash
+
+    Raises:
+      SourceTreeError if we are not able to deduce the previous commit
     """
+
+    assert current_commit
 
     self.pull()
 
@@ -264,21 +277,25 @@ class SourceTree(object):
 
     cmd = "git rev-list --no-merges --committer='GitHub <noreply@github.com>' "
     cmd += "--max-count={revisions} {commit}".format(
-        revisions=revisions, commit=current_commit)
-    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+        revisions=revisions, commit=current_commit
+    )
+
+    output_directory = self.get_source_directory()
+    cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
     hash_list = cmd_exec.run_command(cmd, cmd_params)
 
     # Check whether we got an error from git
     if 'unknown revision or path not in the working tree.' in hash_list:
-      return ''
+      raise SourceTreeError(hash_list)
 
     # Reverse iterate throught the list of hashes, skipping any blank
     # lines that may have trailed the original git output
     for commit_hash in hash_list.split('\n')[::-1]:
       if commit_hash:
+        log.debug(f"Returning {commit_hash} as the previous commit to {current_commit}")
         return commit_hash
 
-    return ''
+    raise SourceTreeError(f"No commit found prior to {current_commit}")
 
   def get_revs_behind_parent_branch(self) -> int:
     """Get the number of commits behind the parent branch.
@@ -292,16 +309,22 @@ class SourceTree(object):
     """
     self._validate()
 
-    if not self._source_path:
-      raise SourceTreeError("Source is not checked out on disk")
-
     cmd = "git status"
-    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    output_directory = self.get_source_directory()
+    cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
     status_output = cmd_exec.run_command(cmd, cmd_params)
 
     commit_count = 0
+
+    # Extract the commit count from lines such as:
+    #
+    # Your branch is ahead of 'origin/master' by 99 commits.
+    #
+    # or determine whether git believes we are up to date:
+    #
+    # Your branch is up to date with 'origin/master'.
     ahead = re.compile(r'.*ahead of \'(.*)\' by (\d+) commit[s]')
-    uptodate = re.compile(r'Your branch is up to date with \'(.*)\'')
+    up_to_date = re.compile(r'Your branch is up to date with \'(.*)\'')
 
     for line in status_output.split('\n'):
       match = ahead.match(line)
@@ -310,7 +333,7 @@ class SourceTree(object):
         log.debug(f"Branch is {commit_count} ahead of branch {match.group(1)}")
         break
 
-      match = uptodate.match(line)
+      match = up_to_date.match(line)
       if match:
         log.debug(f"Branch {match.group(1)} is up to date")
         break
@@ -334,7 +357,8 @@ class SourceTree(object):
     self._validate()
 
     cmd = "git tag --list --sort v:refname"
-    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    output_directory = self.get_source_directory()
+    cmd_params = cmd_exec.CommandParameters(cwd=output_directory)
     tag_output = cmd_exec.run_command(cmd, cmd_params)
 
     tag_list = [tag.strip() for tag in tag_output.split('\n') if tag]

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -1,12 +1,12 @@
-"""This module contains methods for managing a source tree"""
-
+"""Manage a source location on disk"""
+import re
 import logging
 import os
-import re
 import subprocess
 from typing import List
 
 from src.lib import (cmd_exec, constants)
+from src.lib.common import fileops
 
 import api.source_pb2 as proto_source
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 # for a given docker image
 _TAG_REGEX = r'^v\d\.\d+\.\d+'
 
-class SourceTreeException(Exception):
+class SourceTreeError(Exception):
   """Raised if we encounter a condition from which we cannot recover, when
      manipulating SourceTree objects.
   """
@@ -40,24 +40,32 @@ class SourceTree(object):
         with a source tree.
     """
 
-    # Get the temporary directory from fileops module
-    self._tempdir = None
+    # TODO: We need one module that centralizes directory management.  This
+    #       module will have one $HOME path defined and orchestrate sources
+    #       to reduce/eliminate multiple copies of a source tree
+
+    home_dir = '' if not 'HOME' in os.environ else os.environ['HOME']
+    if not home_dir.startswith(constants.SALVO_TMP):
+      home_dir = constants.SALVO_TMP
+
+    self._tempdir = fileops.get_random_dir(home_dir)
 
     self._source_repo = source_repo
-    self._source_url = source_repo.source_url
-    self._branch = source_repo.branch
-    self._commit_hash = source_repo.commit_hash
-    self._source_path = source_repo.source_path
+    self._source_url = self._source_repo.source_url
+    self._branch = self._source_repo.branch
+    self._commit_hash = self._source_repo.commit_hash
+    self._source_path = self._source_repo.source_path
 
   def __repr__(self) -> str:
     """Return a string representation of this class."""
-    return '{name}: Origin: [{origin}] Branch: [{branch}] Hash: [{hash}] \
-      Workdir [{dir}]'.format(
-          name=type(self).__name__,
-          origin=self._source_url,
-          branch=self._branch,
-          hash=self._commit_hash,
-          dir=self._source_path)
+
+    result = f"{type(self).__name__}: "
+    result += f"Origin: [{self._source_url}] "
+    result += f"Branch: [{self._branch}] "
+    result += f"Hash: [{self._commit_hash}] "
+    result += f"Workdir: [{self._source_path}]"
+
+    return result
 
   def _validate(self) -> bool:
     """Verify that we have enough data to work with the source tree.
@@ -67,17 +75,22 @@ class SourceTree(object):
         which to pull the source.
 
     Raises:
-      SourceTreeException: if no path or url is specified for the class to
+      SourceTreeError: if no path or url is specified for the class to
         operate.
     """
 
+    # We have neither a source url nor source on disk.
+    # - This is a non starter and we cannot operate further. We don't know where
+    #   to get the source for building anything
     if all([not self._source_path, not self._source_url]):
-      raise SourceTreeException(
+      raise SourceTreeError(
           "No origin is defined or can be deduced from the path")
 
-    # We must have either a path or an origin url defined
+    # We have a source url and no source on disk -> good.
+    # - We can clone the url to a temporary disk location and work in that
+    #   directory
     if not self._source_path and self._source_url:
-      log.debug(f"No source path.  Using {self._tempdir} for future clone")
+      log.debug(f"No source path. Using {self._tempdir} for future clone")
 
       if not os.path.exists(self._tempdir):
         os.mkdir(self._tempdir)
@@ -85,18 +98,20 @@ class SourceTree(object):
       self._source_path = self._tempdir
       return True
 
-    # We have a working directory on disk and can deduce the origin from it
+    # We have a source url and a source on disk -> good.
+    # - This means we have pulled/cloned the source, or the source is to be
+    #   copied from the specified directory
+    if self._source_path and self._source_url:
+      return True
+
+    # We have a source on disk and no source url -> good
+    # - We can copy the source tree and determine what we need from it.
     if self._source_path and not self._source_url:
       return True
 
-    raise SourceTreeException(
+    log.debug(f"Validation failed for source tree: {self}")
+    raise SourceTreeError(
         "Insufficient information in source definition for it to be usable")
-
-
-  def get_source_identity(self) -> \
-      proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
-    """Returns the identity of the source tree being managed."""
-    return self._source_repo.identity
 
   def get_origin(self) -> str:
     """Detect the origin url from where the code is fetched.
@@ -108,7 +123,23 @@ class SourceTree(object):
         HEAD and the local HEAD.  This diff is applied to the source in the
         remote context.
     """
-    return ''
+    valid = self._validate()
+    log.debug(f"Valid: {valid} for object: {self}")
+
+    origin_url = self._source_url
+
+    cmd = "git remote -v"
+    if not origin_url:
+      cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+      output = cmd_exec.run_command(cmd, cmd_params)
+      for line in output.split('\n'):
+        match = re.match(r'^origin\s*([\w:@\.\/-]+)\s\(fetch\)$', line)
+        if match:
+          origin_url = match.group(1)
+          self._source_url = origin_url
+          break
+
+    return origin_url
 
   def get_directory(self) -> str:
     """Return the full path where the code has been checked out.
@@ -116,7 +147,9 @@ class SourceTree(object):
     Returns:
       a string containing the disk path to the source.
     """
-    return ''
+    self._validate()
+
+    return self._source_path
 
   def pull(self) -> bool:
     """Retrieve the code from the repository.
@@ -127,7 +160,38 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the operation was successful
     """
-    return False
+
+    source_name = proto_source.SourceRepository.SourceIdentity.Name(
+        self._source_repo.identity)
+    log.debug(f"Pulling [{source_name}] from origin: [{self._source_url}]")
+    self._validate()
+
+    try:
+      if self.is_up_to_date():
+        return True
+    except subprocess.CalledProcessError:
+      log.info("Source likely does not exist on disk")
+
+    if not self._source_url:
+      self._source_url = self.get_origin()
+
+    # Clone into the working directory
+    cmd = "git clone {origin} .".format(origin=self._source_url)
+    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    output = cmd_exec.run_command(cmd, cmd_params)
+    expected = 'Cloning into \'.\''
+
+    success = expected in output
+
+    # Since this is a reference to the source in the job control, we should
+    # update the path to the cloned source to avoid a second clone of the
+    # repository.
+    if success and not self._source_repo.source_path:
+      self._source_path = self._tempdir
+      self._source_repo.source_path = self._tempdir
+      log.debug(f"Updated the source path to {self._source_repo.source_path}")
+
+    return success
 
   def checkout_commit_hash(self) -> bool:
     """Checks out the specified commit hash in the source tree
@@ -135,7 +199,30 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the operation was successful
     """
-    return False
+    self._validate()
+
+    # Assume the checkout is successful.  It is possible that it is a no-op
+    # if no commit hashes are specified
+    checkout_success = True
+
+    # Clone the repo if it doesn't exist on disk
+    if not self._source_repo.source_path and self._source_repo.source_url:
+      log.debug("No local source path exists.  Cloning repo for hash discovery")
+      self.pull()
+
+    if self._commit_hash:
+      cmd = "git checkout {hash}".format(hash=self._commit_hash)
+      cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+      output = cmd_exec.run_command(cmd, cmd_params)
+
+      # HEAD is now at <8 chars of hash>
+      expected = "HEAD is now at {commit_hash}".format(
+          commit_hash=self._commit_hash[:8])
+      log.debug(f"Checkout output: {output}")
+
+      checkout_success = expected in output
+
+    return checkout_success
 
   def get_head_hash(self) -> str:
     """Retrieve the hash for the HEAD commit.
@@ -144,7 +231,13 @@ class SourceTree(object):
       a string containing the hash corresponding to commit at the HEAD of the
         tree.
     """
-    return ''
+    self._validate()
+
+    cmd = ("git rev-list --no-merges --committer='GitHub <noreply@github.com>' "
+           "--max-count=1 HEAD")
+
+    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    return cmd_exec.run_command(cmd, cmd_params)
 
   def get_previous_commit_hash(self, current_commit: str,
                                revisions: int = 2) -> str:
@@ -158,6 +251,33 @@ class SourceTree(object):
     Returns:
       a string with the discovered commit hash
     """
+
+    self.pull()
+
+    log.debug(f"Finding previous commit to current commit: [{current_commit}]")
+    if is_tag(current_commit):
+      log.info(f"Current commit \"{current_commit}\" is a tag.")
+      return self.get_previous_tag(current_commit)
+
+    if current_commit == 'latest':
+      current_commit = self.get_head_hash()
+
+    cmd = "git rev-list --no-merges --committer='GitHub <noreply@github.com>' "
+    cmd += "--max-count={revisions} {commit}".format(
+        revisions=revisions, commit=current_commit)
+    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    hash_list = cmd_exec.run_command(cmd, cmd_params)
+
+    # Check whether we got an error from git
+    if 'unknown revision or path not in the working tree.' in hash_list:
+      return ''
+
+    # Reverse iterate throught the list of hashes, skipping any blank
+    # lines that may have trailed the original git output
+    for commit_hash in hash_list.split('\n')[::-1]:
+      if commit_hash:
+        return commit_hash
+
     return ''
 
   def get_revs_behind_parent_branch(self) -> int:
@@ -170,7 +290,32 @@ class SourceTree(object):
       an integer with the number of commits the local source lags
        behind the parent branch
     """
-    return 0
+    self._validate()
+
+    if not self._source_path:
+      raise SourceTreeError("Source is not checked out on disk")
+
+    cmd = "git status"
+    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    status_output = cmd_exec.run_command(cmd, cmd_params)
+
+    commit_count = 0
+    ahead = re.compile(r'.*ahead of \'(.*)\' by (\d+) commit[s]')
+    uptodate = re.compile(r'Your branch is up to date with \'(.*)\'')
+
+    for line in status_output.split('\n'):
+      match = ahead.match(line)
+      if match:
+        commit_count = int(match.group(2))
+        log.debug(f"Branch is {commit_count} ahead of branch {match.group(1)}")
+        break
+
+      match = uptodate.match(line)
+      if match:
+        log.debug(f"Branch {match.group(1)} is up to date")
+        break
+
+    return commit_count
 
   def is_up_to_date(self) -> bool:
     """Determine whether the source tree is up to date.
@@ -178,7 +323,7 @@ class SourceTree(object):
     Returns:
       a boolean indicating whether the tree is up to date.
     """
-    return False
+    return self.get_revs_behind_parent_branch() == 0
 
   def list_tags(self) -> List[str]:
     """Enumerate the repository tags and return them in a list.
@@ -186,7 +331,16 @@ class SourceTree(object):
     Returns:
       a list of tags from the commits
     """
-    return []
+    self._validate()
+
+    cmd = "git tag --list --sort v:refname"
+    cmd_params = cmd_exec.CommandParameters(cwd=self._source_path)
+    tag_output = cmd_exec.run_command(cmd, cmd_params)
+
+    tag_list = [tag.strip() for tag in tag_output.split('\n') if tag]
+    log.debug(f"Repository tags {tag_list}")
+
+    return tag_list
 
   def get_previous_tag(self, current_tag: str, revisions: int = 1) -> str:
     """Identify a tag a number of revisions behind the current tag.
@@ -203,8 +357,28 @@ class SourceTree(object):
       the sought after tag
 
     Raises:
-      SourceTreeException: if the specified tag does not match the tag format
+      SourceTreeError: if the specified tag does not match the tag format
         we expect
 
     """
+    self._validate()
+
+    if not is_tag(current_tag):
+      raise SourceTreeError("The tag specified is not the expected format")
+
+    tag_list = self.list_tags()[::-1]
+
+    count_previous_revisions = False
+    for tag in tag_list:
+      if count_previous_revisions:
+        log.debug(f"Walking {revisions} back from {current_tag}")
+        revisions -= 1
+
+      if revisions == 0:
+        return tag
+
+      if tag == current_tag:
+        log.debug(f"Found {tag} in revision list")
+        count_previous_revisions = True
+
     return ''

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -127,6 +127,10 @@ class SourceTree(object):
         remotely.  We will attempt to generate a patch between the origin
         HEAD and the local HEAD.  This diff is applied to the source in the
         remote context.
+
+    Raises:
+      SourceTreeError: if we are not able to determine the origin url for
+        a managed source tree
     """
     valid = self._validate()
     log.debug(f"Valid: {valid} for object: {self}")

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -12,12 +12,20 @@ import api.source_pb2 as proto_source
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
+_GIT_TAG_LIST = """
+v1.14.5
+v1.15.0
+v1.15.1
+v1.15.2
+v1.16.0
+"""
+
 def test_source_tree_object():
   """Verify that we throw an exception if not all required data is present."""
-  st = source_tree.SourceTree(proto_source.SourceRepository())
+  source = source_tree.SourceTree(proto_source.SourceRepository())
 
   with pytest.raises(source_tree.SourceTreeError) as pull_exception:
-    st.get_head_hash()
+    source.get_head_hash()
 
   assert "No origin is defined or can be" in str(pull_exception.value)
 
@@ -29,9 +37,9 @@ def test_git_with_origin():
   source_repository = proto_source.SourceRepository(
       source_url='somewhere_in_github'
   )
-  st = source_tree.SourceTree(source_repository)
+  source = source_tree.SourceTree(source_repository)
 
-  assert st.get_origin()
+  assert source.get_origin()
 
 
 def test_source_tree_with_local_workdir():
@@ -39,13 +47,13 @@ def test_source_tree_with_local_workdir():
   source_repository = proto_source.SourceRepository(
       source_path='/some_source_path'
   )
-  st = source_tree.SourceTree(source_repository)
+  source = source_tree.SourceTree(source_repository)
 
   remote_string = 'origin  git@github.com:username/reponame.git (fetch)'
 
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=remote_string)) as magic_mock:
-    origin = st.get_origin()
+    origin = source.get_origin()
     assert origin == "git@github.com:username/reponame.git"
 
     cmd_params = cmd_exec.CommandParameters(cwd='/some_source_path')
@@ -57,19 +65,19 @@ def test_get_origin_ssh():
   In this instance the repo was cloned via ssh.
   """
   remote_string = 'origin  git@github.com:username/reponame.git (fetch)'
-  gitcmd = "git remote -v"
+  git_cmd = "git remote -v"
 
   source_repository = proto_source.SourceRepository(
       source_path='/tmp'
   )
-  st = source_tree.SourceTree(source_repository)
+  source = source_tree.SourceTree(source_repository)
 
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=remote_string)) as magic_mock:
-    origin_url = st.get_origin()
+    origin_url = source.get_origin()
 
     cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert origin_url == 'git@github.com:username/reponame.git'
 
@@ -80,18 +88,18 @@ def test_get_origin_https():
   """
   remote_string = \
       'origin	https://github.com/aws/aws-app-mesh-examples.git (fetch)'
-  gitcmd = "git remote -v"
+  git_cmd = "git remote -v"
 
   source_repository = proto_source.SourceRepository(
       source_path='/tmp'
   )
-  st = source_tree.SourceTree(source_repository)
+  source = source_tree.SourceTree(source_repository)
 
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=remote_string)) as magic_mock:
-    origin_url = st.get_origin()
+    origin_url = source.get_origin()
     cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert origin_url == 'https://github.com/aws/aws-app-mesh-examples.git'
 
@@ -103,19 +111,52 @@ def _generate_source_tree_from_origin(origin):
   )
   return source_tree.SourceTree(source_repository)
 
-def mock_run_command_side_effect(*args):
-  """Mock run_command side effect for checkout operation."""
-  if args[0] == 'git status':
+def mock_run_command_side_effect(*function_args):
+  """Mock run_command side effect for checkout operation.
+
+  Args:
+    function_args:  This is a list of arguments passed to the mocked
+      function.  In this case the first entry is the shell command being
+      executed and the second parameter is the cmd_exec.CommandParameters
+      tuple containing the working directory.
+
+      We are most interested in the contents of the first entry.
+  """
+  if function_args[0] == 'git status':
     raise subprocess.CalledProcessError(1, "msg")
-  elif args[0] == 'git remote -v':
+  elif function_args[0] == 'git remote -v':
     return \
         ("origin  https://www.github.com/_some_random_repo_/repo.git (fetch)\n"
          "origin  https://www.github.com/_some_random_repo_/repo.git (push)")
-  elif args[0] == \
+  elif function_args[0] == \
       'git clone https://www.github.com/_some_random_repo_/repo.git .':
     return "Cloning into \'.\'"
 
-  raise NotImplementedError(f"Unhandled arguments: {args}")
+  elif function_args[0] == \
+      "git clone https://github.com/_some_random_repo_/repo.git .":
+    return "Cloning into \'.\'"
+
+  elif function_args[0] == (
+      "git rev-list --no-merges "
+      "--committer=\'GitHub <noreply@github.com>\' "
+      "--max-count=2 fake_commit_hash_1"):
+    return ("fake_commit_hash_1\n"
+            "fake_commit_hash_2\n")
+
+  elif function_args[0] == (
+      "git rev-list --no-merges "
+      "--committer=\'GitHub <noreply@github.com>\' "
+      "--max-count=2 invalid_hash_reference"):
+    git_output = """fatal: ambiguous argument 'invalid_hash_reference': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+"""
+    return git_output
+
+  elif function_args[0] == "git status":
+    return "Your branch is up to date with \'some_random_branch\'"
+
+  raise NotImplementedError(f"Unhandled arguments: {function_args}")
 
 @mock.patch("src.lib.cmd_exec.run_command")
 def test_source_tree_pull(mock_run_command):
@@ -124,10 +165,10 @@ def test_source_tree_pull(mock_run_command):
   """
   origin = 'https://www.github.com/_some_random_repo_/repo.git'
 
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
   mock_run_command.side_effect = mock_run_command_side_effect
 
-  result = st.pull()
+  result = source.pull()
   assert result
 
   git_status = 'git status'
@@ -140,22 +181,32 @@ def test_source_tree_pull(mock_run_command):
   ]
   mock_run_command.assert_has_calls(calls)
 
-  origin_url = st.get_origin()
+  origin_url = source.get_origin()
   assert origin_url == origin
 
-def mock_run_command_side_effect_failure(*args):
-  """Mock run_command side effect for checkout operation."""
-  if args[0] == 'git status':
+def mock_run_command_side_effect_failure(*function_args):
+  """Mock run_command side effect for a failed checkout operation.
+
+  Args:
+    function_args:  This is a list of arguments passed to the mocked
+      function.  In this case the first entry is the shell command being
+      executed and the second parameter is the cmd_exec.CommandParameters
+      tuple containing the working directory.
+
+      We are most interested in the contents of the first entry.
+  """
+
+  if function_args[0] == 'git status':
     raise subprocess.CalledProcessError(1, "msg")
-  elif args[0] == 'git remote -v':
+  elif function_args[0] == 'git remote -v':
     return \
         ("origin  https://github.com/someawesomeproject/repo.git (fetch)\n"
          "origin  https://github.com/someawesomeproject/repo.git (push)")
-  elif args[0] == \
+  elif function_args[0] == \
       'git clone https://github.com/someawesomeproject/repo.git .':
     return "Something failed during a clone...'"
 
-  raise NotImplementedError(f"Unhandled arguments: {args}")
+  raise NotImplementedError(f"Unhandled arguments: {function_args}")
 
 @mock.patch("src.lib.cmd_exec.run_command")
 def test_source_tree_pull_failure(mock_run_command):
@@ -163,7 +214,7 @@ def test_source_tree_pull_failure(mock_run_command):
      operation.
   """
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
   mock_run_command.side_effect = mock_run_command_side_effect_failure
 
@@ -171,7 +222,7 @@ def test_source_tree_pull_failure(mock_run_command):
   git_clone = 'git clone https://github.com/someawesomeproject/repo.git .'
   cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
 
-  result = st.pull()
+  result = source.pull()
   assert not result
 
   calls = [
@@ -180,115 +231,57 @@ def test_source_tree_pull_failure(mock_run_command):
   ]
   mock_run_command.assert_has_calls(calls)
 
-  assert st.get_origin() == origin
+  assert source.get_origin() == origin
 
 def test_retrieve_head_hash():
   """Verify that we can determine the hash for the head commit."""
 
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
-  gitcmd = ("git rev-list --no-merges --committer='GitHub <noreply@github.com>'"
+  git_cmd = ("git rev-list --no-merges --committer='GitHub <noreply@github.com>'"
             " --max-count=1 HEAD")
   git_output = "some_long_hex_string_that_is_the_hash"
 
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=git_output)) as magic_mock:
-    hash_string = st.get_head_hash()
+    hash_string = source.get_head_hash()
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert hash_string == git_output
-
-def _check_output_side_effect(*args):
-  """Respond to the mocked function call with the correct output.
-
-  Args:
-    args: the arguments supplied to the mock.  The first argument is the
-      command being executed.
-  """
-
-  kwargs = args[1]._asdict()
-  assert 'cwd' in kwargs
-  assert kwargs['cwd']
-
-  if args[0] == 'git remote -v':
-    return 'origin https://github.com/someawesomeproject/repo.git (fetch)'
-
-  elif args[0] == \
-      "git clone https://github.com/someawesomeproject/repo.git .":
-    return "Cloning into \'.\'"
-
-  elif args[0] == ("git rev-list --no-merges "
-                   "--committer=\'GitHub <noreply@github.com>\' "
-                   "--max-count=2 fake_commit_hash_1"):
-    return ("fake_commit_hash_1\n"
-            "fake_commit_hash_2\n")
-
-  elif args[0] == "git status":
-    return "Your branch is up to date with \'some_random_branch\'"
-
-  raise NotImplementedError("Unhandled argument in side effect: %s" % args)
 
 @mock.patch('src.lib.cmd_exec.run_command')
 def test_get_previous_commit(mock_check_output):
   """
     Verify that we can identify one commit prior to a specified hash.
     """
-  origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  origin = 'https://github.com/_some_random_repo_/repo.git'
+  source = _generate_source_tree_from_origin(origin)
 
   commit_hash = 'fake_commit_hash_1'
 
-  mock_check_output.side_effect = _check_output_side_effect
-  hash_string = st.get_previous_commit_hash(commit_hash)
+  mock_check_output.return_value = 'fake_commit_hash_2'
+  hash_string = source.get_previous_commit_hash(commit_hash)
   assert hash_string == 'fake_commit_hash_2'
-
-def _check_output_side_effect_fail(*args):
-  """Respond to the mocked function call with the correct output.
-
-  Args:
-    args: the arguments supplied to the mock.  The first argument is the
-      command being executed.
-  """
-  kwargs = args[1]._asdict()
-  assert 'cwd' in kwargs
-  assert kwargs['cwd']
-
-  if args[0] == 'git remote -v':
-    return 'origin https://github.com/someawesomeproject/repo.git (fetch)'
-
-  elif args[0] == \
-      "git clone https://github.com/someawesomeproject/repo.git .":
-    return "Cloning into \'.\'"
-
-  elif args[0] == ("git rev-list --no-merges "
-                   "--committer=\'GitHub <noreply@github.com>\' "
-                   "--max-count=2 invalid_hash_reference"):
-    git_output = """fatal: ambiguous argument 'invalid_hash_reference_': unknown revision or path not in the working tree.
-Use '--' to separate paths from revisions, like this:
-'git <command> [<revision>...] -- [<file>...]'
-"""
-    return git_output
-
-  elif args[0] == "git status":
-    return "Your branch is up to date with \'some_random_branch\'"
-
-  raise NotImplementedError("Unhandled argument in side effect: %s" % args)
 
 @mock.patch('src.lib.cmd_exec.run_command')
 def test_get_previous_commit_fail(mock_check_output):
   """Verify that we can identify a failure when attempting to manage commit
      hashes.
   """
-  origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  origin = 'https://github.com/_some_random_repo_/repo.git'
+  source = _generate_source_tree_from_origin(origin)
 
   commit_hash = 'invalid_hash_reference'
 
-  mock_check_output.side_effect = _check_output_side_effect_fail
-  hash_string = st.get_previous_commit_hash(commit_hash)
-  assert not hash_string
+  mock_check_output.side_effect = mock_run_command_side_effect
+
+  with pytest.raises(source_tree.SourceTreeError) as source_error:
+    source.get_previous_commit_hash(commit_hash)
+
+  assert "fatal: ambiguous argument \'invalid_hash_reference\'" in \
+      str(source_error.value)
 
 def test_parent_branch_ahead():
   """Verify that we can determine how many commits beind the local source tree
@@ -297,7 +290,7 @@ def test_parent_branch_ahead():
   origin = 'https://github.com/someawesomeproject/repo.git'
   st = _generate_source_tree_from_origin(origin)
 
-  gitcmd = 'git status'
+  git_cmd = 'git status'
   git_output = """On branch master
 Your branch is ahead of 'origin/master' by 99 commits.
   (use "git push" to publish your local commits)
@@ -308,7 +301,7 @@ nothing to commit, working tree clean
                   mock.MagicMock(return_value=git_output)) as magic_mock:
     commit_count = st.get_revs_behind_parent_branch()
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert isinstance(commit_count, int)
     assert commit_count == 99
@@ -318,9 +311,9 @@ def test_parent_branch_up_to_date():
      lags behind the remote repository.
   """
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
-  gitcmd = 'git status'
+  git_cmd = 'git status'
   git_output = """On branch master
 Your branch is up to date with 'origin/master'.
 
@@ -330,9 +323,9 @@ Changes not staged for commit:
 """
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=git_output)) as magic_mock:
-    commit_count = st.get_revs_behind_parent_branch()
+    commit_count = source.get_revs_behind_parent_branch()
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert isinstance(commit_count, int)
     assert commit_count == 0
@@ -341,78 +334,34 @@ def test_branch_up_to_date():
   """Verify that we can determine a source tree is up to date."""
 
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
   with mock.patch(
       'src.lib.source_tree.SourceTree.get_revs_behind_parent_branch',
       mock.MagicMock(return_value=0)) as magic_mock:
-    up_to_date = st.is_up_to_date()
+    up_to_date = source.is_up_to_date()
     magic_mock.assert_called_once()
     assert up_to_date
-
 
 def test_list_tags():
   """Verify that we can list tags from a repository."""
 
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
-  gitcmd = "git tag --list --sort v:refname"
-  git_output = """v1.0.0
-v1.1.0
-v1.2.0
-v1.3.0
-v1.4.0
-v1.5.0
-v1.6.0
-v1.7.0
-v1.7.1
-v1.8.0
-v1.9.0
-v1.9.1
-v1.10.0
-v1.11.0
-v1.11.1
-v1.11.2
-v1.12.0
-v1.12.1
-v1.12.2
-v1.12.3
-v1.12.4
-v1.12.5
-v1.12.6
-v1.12.7
-v1.13.0
-v1.13.1
-v1.13.2
-v1.13.3
-v1.13.4
-v1.13.5
-v1.13.6
-v1.14.0
-v1.14.1
-v1.14.2
-v1.14.3
-v1.14.4
-v1.14.5
-v1.15.0
-v1.15.1
-v1.15.2
-v1.16.0
-"""
-
+  git_cmd = "git tag --list --sort v:refname"
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=git_output)) as magic_mock:
+                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
 
-    tags_list = st.list_tags()
+    tags_list = source.list_tags()
     expected_tags_list = [
-        tag for tag in git_output.split('\n') if tag
+        tag for tag in _GIT_TAG_LIST.split('\n') if tag
     ]
 
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
-    assert tags_list != []
+    assert tags_list
     assert tags_list == expected_tags_list
 
 def test_is_tag():
@@ -426,145 +375,61 @@ def test_is_tag():
 def test_get_previous_tag():
   """Verify that we can identify the previous tag for a given release."""
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'
   previous_tag = 'v1.15.2'
 
-  gitcmd = "git tag --list --sort v:refname"
-  git_output = """v1.0.0
-v1.1.0
-v1.2.0
-v1.3.0
-v1.4.0
-v1.5.0
-v1.6.0
-v1.7.0
-v1.7.1
-v1.8.0
-v1.9.0
-v1.9.1
-v1.10.0
-v1.11.0
-v1.11.1
-v1.11.2
-v1.12.0
-v1.12.1
-v1.12.2
-v1.12.3
-v1.12.4
-v1.12.5
-v1.12.6
-v1.12.7
-v1.13.0
-v1.13.1
-v1.13.2
-v1.13.3
-v1.13.4
-v1.13.5
-v1.13.6
-v1.14.0
-v1.14.1
-v1.14.2
-v1.14.3
-v1.14.4
-v1.14.5
-v1.15.0
-v1.15.1
-v1.15.2
-v1.16.0
-"""
+  git_cmd = "git tag --list --sort v:refname"
 
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=git_output)) as magic_mock:
+                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
 
-    previous_tag = st.get_previous_tag(current_tag)
+    previous_tag = source.get_previous_tag(current_tag)
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert previous_tag == previous_tag
 
 def test_get_previous_n_tag():
   """Verify that we can identify the previous tag for a given release."""
   origin = 'https://github.com/someawesomeproject/repo.git'
-  st = _generate_source_tree_from_origin(origin)
+  source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'
   previous_tag = 'v1.14.5'
 
-  gitcmd = "git tag --list --sort v:refname"
-  git_output = """v1.0.0
-v1.1.0
-v1.2.0
-v1.3.0
-v1.4.0
-v1.5.0
-v1.6.0
-v1.7.0
-v1.7.1
-v1.8.0
-v1.9.0
-v1.9.1
-v1.10.0
-v1.11.0
-v1.11.1
-v1.11.2
-v1.12.0
-v1.12.1
-v1.12.2
-v1.12.3
-v1.12.4
-v1.12.5
-v1.12.6
-v1.12.7
-v1.13.0
-v1.13.1
-v1.13.2
-v1.13.3
-v1.13.4
-v1.13.5
-v1.13.6
-v1.14.0
-v1.14.1
-v1.14.2
-v1.14.3
-v1.14.4
-v1.14.5
-v1.15.0
-v1.15.1
-v1.15.2
-v1.16.0
-"""
+  git_cmd = "git tag --list --sort v:refname"
 
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=git_output)) as magic_mock:
+                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
 
-    previous_tag = st.get_previous_tag(current_tag, revisions=4)
+    previous_tag = source.get_previous_tag(current_tag, revisions=4)
 
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert previous_tag == previous_tag
 
 def test_source_tree_with_disk_files():
   """Verify that we can get hash data from a source tree on disk."""
 
-  st = source_tree.SourceTree(proto_source.SourceRepository(
+  source = source_tree.SourceTree(proto_source.SourceRepository(
       identity=proto_source.SourceRepository.SRCID_ENVOY,
       source_path='/tmp',
       commit_hash='fake_commit_hash'
   ))
   git_output = 'origin  git@github.com:username/reponame.git (fetch)'
-  gitcmd = "git remote -v"
+  git_cmd = "git remote -v"
 
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=git_output)) as magic_mock:
 
-    origin = st.get_origin()
+    origin = source.get_origin()
     assert origin
 
     cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
-    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+    magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
 
 if __name__ == '__main__':

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -12,14 +12,6 @@ import api.source_pb2 as proto_source
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
-_GIT_TAG_LIST = """
-v1.14.5
-v1.15.0
-v1.15.1
-v1.15.2
-v1.16.0
-"""
-
 def test_source_tree_object():
   """Verify that we throw an exception if not all required data is present."""
   source = source_tree.SourceTree(proto_source.SourceRepository())
@@ -346,16 +338,21 @@ def test_branch_up_to_date():
 def test_list_tags():
   """Verify that we can list tags from a repository."""
 
+  GIT_TAG_LIST = """
+v1.15.2
+v1.16.0
+"""
+
   origin = 'https://github.com/someawesomeproject/repo.git'
   source = _generate_source_tree_from_origin(origin)
 
   git_cmd = "git tag --list --sort v:refname"
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
+                  mock.MagicMock(return_value=GIT_TAG_LIST)) as magic_mock:
 
     tags_list = source.list_tags()
     expected_tags_list = [
-        tag for tag in _GIT_TAG_LIST.split('\n') if tag
+        tag for tag in GIT_TAG_LIST.split('\n') if tag
     ]
 
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
@@ -374,6 +371,12 @@ def test_is_tag():
 
 def test_get_previous_tag():
   """Verify that we can identify the previous tag for a given release."""
+
+  GIT_TAG_LIST = """
+v1.15.2
+v1.16.0
+"""
+
   origin = 'https://github.com/someawesomeproject/repo.git'
   source = _generate_source_tree_from_origin(origin)
 
@@ -383,7 +386,7 @@ def test_get_previous_tag():
   git_cmd = "git tag --list --sort v:refname"
 
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
+                  mock.MagicMock(return_value=GIT_TAG_LIST)) as magic_mock:
 
     previous_tag = source.get_previous_tag(current_tag)
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
@@ -393,6 +396,14 @@ def test_get_previous_tag():
 
 def test_get_previous_n_tag():
   """Verify that we can identify the previous tag for a given release."""
+
+  GIT_TAG_LIST = """
+v1.14.5
+v1.15.0
+v1.15.1
+v1.15.2
+v1.16.0
+"""
   origin = 'https://github.com/someawesomeproject/repo.git'
   source = _generate_source_tree_from_origin(origin)
 
@@ -402,7 +413,7 @@ def test_get_previous_n_tag():
   git_cmd = "git tag --list --sort v:refname"
 
   with mock.patch('src.lib.cmd_exec.run_command',
-                  mock.MagicMock(return_value=_GIT_TAG_LIST)) as magic_mock:
+                  mock.MagicMock(return_value=GIT_TAG_LIST)) as magic_mock:
 
     previous_tag = source.get_previous_tag(current_tag, revisions=4)
 

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -9,65 +9,196 @@ import subprocess
 from src.lib import (cmd_exec, source_tree)
 import api.source_pb2 as proto_source
 
+logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 def test_source_tree_object():
   """Verify that we throw an exception if not all required data is present."""
-  pass
+  st = source_tree.SourceTree(proto_source.SourceRepository())
+
+  with pytest.raises(source_tree.SourceTreeError) as pull_exception:
+    st.get_head_hash()
+
+  assert "No origin is defined or can be" in str(pull_exception.value)
+
 
 def test_git_with_origin():
   """Verify that at a minimum, we can work with a remote origin url
      specified.
   """
-  pass
+  source_repository = proto_source.SourceRepository(
+      source_url='somewhere_in_github'
+  )
+  st = source_tree.SourceTree(source_repository)
+
+  assert st.get_origin()
+
 
 def test_source_tree_with_local_workdir():
   """Verify that we can work with a source location on disk."""
-  pass
+  source_repository = proto_source.SourceRepository(
+      source_path='/some_source_path'
+  )
+  st = source_tree.SourceTree(source_repository)
+
+  remote_string = 'origin  git@github.com:username/reponame.git (fetch)'
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=remote_string)) as magic_mock:
+    origin = st.get_origin()
+    assert origin == "git@github.com:username/reponame.git"
+
+    cmd_params = cmd_exec.CommandParameters(cwd='/some_source_path')
+    magic_mock.assert_called_once_with("git remote -v", cmd_params)
 
 def test_get_origin_ssh():
   """Verify that we can determine the origin for a local repository.
 
   In this instance the repo was cloned via ssh.
   """
-  pass
+  remote_string = 'origin  git@github.com:username/reponame.git (fetch)'
+  gitcmd = "git remote -v"
+
+  source_repository = proto_source.SourceRepository(
+      source_path='/tmp'
+  )
+  st = source_tree.SourceTree(source_repository)
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=remote_string)) as magic_mock:
+    origin_url = st.get_origin()
+
+    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert origin_url == 'git@github.com:username/reponame.git'
 
 def test_get_origin_https():
   """Verify that we can determine the origin for a local repository.
 
   In this instance the repo was cloned via https
   """
-  pass
+  remote_string = \
+      'origin	https://github.com/aws/aws-app-mesh-examples.git (fetch)'
+  gitcmd = "git remote -v"
+
+  source_repository = proto_source.SourceRepository(
+      source_path='/tmp'
+  )
+  st = source_tree.SourceTree(source_repository)
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=remote_string)) as magic_mock:
+    origin_url = st.get_origin()
+    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert origin_url == 'https://github.com/aws/aws-app-mesh-examples.git'
 
 def _generate_source_tree_from_origin(origin):
   """Build a source tree from a remote url."""
-  pass
+  source_repository = proto_source.SourceRepository(
+      source_path='/tmp',
+      source_url=origin
+  )
+  return source_tree.SourceTree(source_repository)
 
 def mock_run_command_side_effect(*args):
   """Mock run_command side effect for checkout operation."""
-  pass
+  if args[0] == 'git status':
+    raise subprocess.CalledProcessError(1, "msg")
+  elif args[0] == 'git remote -v':
+    return \
+        ("origin  https://www.github.com/_some_random_repo_/repo.git (fetch)\n"
+         "origin  https://www.github.com/_some_random_repo_/repo.git (push)")
+  elif args[0] == \
+      'git clone https://www.github.com/_some_random_repo_/repo.git .':
+    return "Cloning into \'.\'"
+
+  raise NotImplementedError(f"Unhandled arguments: {args}")
 
 @mock.patch("src.lib.cmd_exec.run_command")
 def test_source_tree_pull(mock_run_command):
   """Verify that we can clone a repository ensuring that the process completed
      without errors.
   """
-  pass
+  origin = 'https://www.github.com/_some_random_repo_/repo.git'
+
+  st = _generate_source_tree_from_origin(origin)
+  mock_run_command.side_effect = mock_run_command_side_effect
+
+  result = st.pull()
+  assert result
+
+  git_status = 'git status'
+  git_clone = 'git clone https://www.github.com/_some_random_repo_/repo.git .'
+  cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+
+  calls = [
+      mock.call(git_status, cmd_params),
+      mock.call(git_clone, cmd_params)
+  ]
+  mock_run_command.assert_has_calls(calls)
+
+  origin_url = st.get_origin()
+  assert origin_url == origin
 
 def mock_run_command_side_effect_failure(*args):
   """Mock run_command side effect for checkout operation."""
-  pass
+  if args[0] == 'git status':
+    raise subprocess.CalledProcessError(1, "msg")
+  elif args[0] == 'git remote -v':
+    return \
+        ("origin  https://github.com/someawesomeproject/repo.git (fetch)\n"
+         "origin  https://github.com/someawesomeproject/repo.git (push)")
+  elif args[0] == \
+      'git clone https://github.com/someawesomeproject/repo.git .':
+    return "Something failed during a clone...'"
+
+  raise NotImplementedError(f"Unhandled arguments: {args}")
 
 @mock.patch("src.lib.cmd_exec.run_command")
 def test_source_tree_pull_failure(mock_run_command):
   """Verify that we can clone a repository and detect an incomplete
      operation.
   """
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  mock_run_command.side_effect = mock_run_command_side_effect_failure
+
+  git_status = 'git status'
+  git_clone = 'git clone https://github.com/someawesomeproject/repo.git .'
+  cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+
+  result = st.pull()
+  assert not result
+
+  calls = [
+      mock.call(git_status, cmd_params),
+      mock.call(git_clone, cmd_params)
+  ]
+  mock_run_command.assert_has_calls(calls)
+
+  assert st.get_origin() == origin
 
 def test_retrieve_head_hash():
   """Verify that we can determine the hash for the head commit."""
-  pass
+
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  gitcmd = ("git rev-list --no-merges --committer='GitHub <noreply@github.com>'"
+            " --max-count=1 HEAD")
+  git_output = "some_long_hex_string_that_is_the_hash"
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+    hash_string = st.get_head_hash()
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert hash_string == git_output
 
 def _check_output_side_effect(*args):
   """Respond to the mocked function call with the correct output.
@@ -75,17 +206,43 @@ def _check_output_side_effect(*args):
   Args:
     args: the arguments supplied to the mock.  The first argument is the
       command being executed.
-
-    kwargs: the keyword arguments supplied to the mock. In this case
-      the 'cwd' (working directory) is the one keyword that should always
-      be present
   """
-  pass
+
+  kwargs = args[1]._asdict()
+  assert 'cwd' in kwargs
+  assert kwargs['cwd']
+
+  if args[0] == 'git remote -v':
+    return 'origin https://github.com/someawesomeproject/repo.git (fetch)'
+
+  elif args[0] == \
+      "git clone https://github.com/someawesomeproject/repo.git .":
+    return "Cloning into \'.\'"
+
+  elif args[0] == ("git rev-list --no-merges "
+                   "--committer=\'GitHub <noreply@github.com>\' "
+                   "--max-count=2 fake_commit_hash_1"):
+    return ("fake_commit_hash_1\n"
+            "fake_commit_hash_2\n")
+
+  elif args[0] == "git status":
+    return "Your branch is up to date with \'some_random_branch\'"
+
+  raise NotImplementedError("Unhandled argument in side effect: %s" % args)
 
 @mock.patch('src.lib.cmd_exec.run_command')
 def test_get_previous_commit(mock_check_output):
-  """Verify that we can identify one commit prior to a specified hash. """
-  pass
+  """
+    Verify that we can identify one commit prior to a specified hash.
+    """
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  commit_hash = 'fake_commit_hash_1'
+
+  mock_check_output.side_effect = _check_output_side_effect
+  hash_string = st.get_previous_commit_hash(commit_hash)
+  assert hash_string == 'fake_commit_hash_2'
 
 def _check_output_side_effect_fail(*args):
   """Respond to the mocked function call with the correct output.
@@ -94,50 +251,321 @@ def _check_output_side_effect_fail(*args):
     args: the arguments supplied to the mock.  The first argument is the
       command being executed.
   """
-  pass
+  kwargs = args[1]._asdict()
+  assert 'cwd' in kwargs
+  assert kwargs['cwd']
+
+  if args[0] == 'git remote -v':
+    return 'origin https://github.com/someawesomeproject/repo.git (fetch)'
+
+  elif args[0] == \
+      "git clone https://github.com/someawesomeproject/repo.git .":
+    return "Cloning into \'.\'"
+
+  elif args[0] == ("git rev-list --no-merges "
+                   "--committer=\'GitHub <noreply@github.com>\' "
+                   "--max-count=2 invalid_hash_reference"):
+    git_output = """fatal: ambiguous argument 'invalid_hash_reference_': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+"""
+    return git_output
+
+  elif args[0] == "git status":
+    return "Your branch is up to date with \'some_random_branch\'"
+
+  raise NotImplementedError("Unhandled argument in side effect: %s" % args)
 
 @mock.patch('src.lib.cmd_exec.run_command')
 def test_get_previous_commit_fail(mock_check_output):
   """Verify that we can identify a failure when attempting to manage commit
      hashes.
   """
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  commit_hash = 'invalid_hash_reference'
+
+  mock_check_output.side_effect = _check_output_side_effect_fail
+  hash_string = st.get_previous_commit_hash(commit_hash)
+  assert not hash_string
 
 def test_parent_branch_ahead():
   """Verify that we can determine how many commits beind the local source tree
      lags behind the remote repository.
   """
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  gitcmd = 'git status'
+  git_output = """On branch master
+Your branch is ahead of 'origin/master' by 99 commits.
+  (use "git push" to publish your local commits)
+
+nothing to commit, working tree clean
+"""
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+    commit_count = st.get_revs_behind_parent_branch()
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert isinstance(commit_count, int)
+    assert commit_count == 99
 
 def test_parent_branch_up_to_date():
   """Verify that we can determine how many commits beind the local source tree
      lags behind the remote repository.
   """
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  gitcmd = 'git status'
+  git_output = """On branch master
+Your branch is up to date with 'origin/master'.
+
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git checkout -- <file>..." to discard changes in working directory)
+"""
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+    commit_count = st.get_revs_behind_parent_branch()
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert isinstance(commit_count, int)
+    assert commit_count == 0
 
 def test_branch_up_to_date():
   """Verify that we can determine a source tree is up to date."""
-  pass
+
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  with mock.patch(
+      'src.lib.source_tree.SourceTree.get_revs_behind_parent_branch',
+      mock.MagicMock(return_value=0)) as magic_mock:
+    up_to_date = st.is_up_to_date()
+    magic_mock.assert_called_once()
+    assert up_to_date
+
 
 def test_list_tags():
   """Verify that we can list tags from a repository."""
-  pass
+
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  gitcmd = "git tag --list --sort v:refname"
+  git_output = """v1.0.0
+v1.1.0
+v1.2.0
+v1.3.0
+v1.4.0
+v1.5.0
+v1.6.0
+v1.7.0
+v1.7.1
+v1.8.0
+v1.9.0
+v1.9.1
+v1.10.0
+v1.11.0
+v1.11.1
+v1.11.2
+v1.12.0
+v1.12.1
+v1.12.2
+v1.12.3
+v1.12.4
+v1.12.5
+v1.12.6
+v1.12.7
+v1.13.0
+v1.13.1
+v1.13.2
+v1.13.3
+v1.13.4
+v1.13.5
+v1.13.6
+v1.14.0
+v1.14.1
+v1.14.2
+v1.14.3
+v1.14.4
+v1.14.5
+v1.15.0
+v1.15.1
+v1.15.2
+v1.16.0
+"""
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+
+    tags_list = st.list_tags()
+    expected_tags_list = [
+        tag for tag in git_output.split('\n') if tag
+    ]
+
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert tags_list != []
+    assert tags_list == expected_tags_list
 
 def test_is_tag():
   """Verify that we can detect a hash and a git tag."""
-  pass
+  commit_hash = 'obviously_not_a_tag'
+  tag_string = 'v1.15.1'
+
+  assert not source_tree.is_tag(commit_hash)
+  assert source_tree.is_tag(tag_string)
 
 def test_get_previous_tag():
   """Verify that we can identify the previous tag for a given release."""
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  current_tag = 'v1.16.0'
+  previous_tag = 'v1.15.2'
+
+  gitcmd = "git tag --list --sort v:refname"
+  git_output = """v1.0.0
+v1.1.0
+v1.2.0
+v1.3.0
+v1.4.0
+v1.5.0
+v1.6.0
+v1.7.0
+v1.7.1
+v1.8.0
+v1.9.0
+v1.9.1
+v1.10.0
+v1.11.0
+v1.11.1
+v1.11.2
+v1.12.0
+v1.12.1
+v1.12.2
+v1.12.3
+v1.12.4
+v1.12.5
+v1.12.6
+v1.12.7
+v1.13.0
+v1.13.1
+v1.13.2
+v1.13.3
+v1.13.4
+v1.13.5
+v1.13.6
+v1.14.0
+v1.14.1
+v1.14.2
+v1.14.3
+v1.14.4
+v1.14.5
+v1.15.0
+v1.15.1
+v1.15.2
+v1.16.0
+"""
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+
+    previous_tag = st.get_previous_tag(current_tag)
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert previous_tag == previous_tag
 
 def test_get_previous_n_tag():
   """Verify that we can identify the previous tag for a given release."""
-  pass
+  origin = 'https://github.com/someawesomeproject/repo.git'
+  st = _generate_source_tree_from_origin(origin)
+
+  current_tag = 'v1.16.0'
+  previous_tag = 'v1.14.5'
+
+  gitcmd = "git tag --list --sort v:refname"
+  git_output = """v1.0.0
+v1.1.0
+v1.2.0
+v1.3.0
+v1.4.0
+v1.5.0
+v1.6.0
+v1.7.0
+v1.7.1
+v1.8.0
+v1.9.0
+v1.9.1
+v1.10.0
+v1.11.0
+v1.11.1
+v1.11.2
+v1.12.0
+v1.12.1
+v1.12.2
+v1.12.3
+v1.12.4
+v1.12.5
+v1.12.6
+v1.12.7
+v1.13.0
+v1.13.1
+v1.13.2
+v1.13.3
+v1.13.4
+v1.13.5
+v1.13.6
+v1.14.0
+v1.14.1
+v1.14.2
+v1.14.3
+v1.14.4
+v1.14.5
+v1.15.0
+v1.15.1
+v1.15.2
+v1.16.0
+"""
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+
+    previous_tag = st.get_previous_tag(current_tag, revisions=4)
+
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
+    assert previous_tag == previous_tag
 
 def test_source_tree_with_disk_files():
   """Verify that we can get hash data from a source tree on disk."""
-  pass
+
+  st = source_tree.SourceTree(proto_source.SourceRepository(
+      identity=proto_source.SourceRepository.SRCID_ENVOY,
+      source_path='/tmp',
+      commit_hash='fake_commit_hash'
+  ))
+  git_output = 'origin  git@github.com:username/reponame.git (fetch)'
+  gitcmd = "git remote -v"
+
+  with mock.patch('src.lib.cmd_exec.run_command',
+                  mock.MagicMock(return_value=git_output)) as magic_mock:
+
+    origin = st.get_origin()
+    assert origin
+
+    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    magic_mock.assert_called_once_with(gitcmd, cmd_params)
+
 
 if __name__ == '__main__':
   raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
Add the `source_tree` module that abstracts git operations to manipulate and deduce information about a source tree.

Unit tests for the source tree module are included in this diff.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k , @landesherr