### PR TITLE
Use TemporaryDirectory vs string for temp directories

### DIFF
--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -35,6 +35,11 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
     subprocess.CalledProcessError if there was a failure executing the specified
       command
   """
+
+  # Because the stdout/stderr from nighthawk can be large, we redirect it to
+  # a temporary file and re-read the output to return to the caller.  This
+  # method also appears to capture output more consistently in the event of a
+  # failed command execution.
   output = ''
   params = parameters._asdict()
   tmpfile = tempfile.TemporaryFile(

--- a/salvo/src/lib/common/BUILD
+++ b/salvo/src/lib/common/BUILD
@@ -10,6 +10,7 @@ py_library(
         "file_ops.py",
     ],
 )
+
 py_test(
     name = "test_file_ops",
     srcs = ["test_file_ops.py"],

--- a/salvo/src/lib/common/file_ops.py
+++ b/salvo/src/lib/common/file_ops.py
@@ -2,10 +2,8 @@
 Module to abstract a few common file operations used in the framework
 """
 import json
-import random
 import shutil
 import yaml
-import glob
 import os
 import tempfile
 
@@ -25,7 +23,8 @@ def open_json(path: str, mode: str = 'r') -> dict:
 
 
 def open_yaml(path: str, mode: str = 'r') -> dict:
-  """Open a yaml file and return its contents as a dictionary 
+  """Open a yaml file and return its contents as a dictionary
+
   Args:
     path: the full path to the YAML file
     mode: the mode with which we open the file.  The mode defaults
@@ -46,11 +45,8 @@ def delete_directory(path: str) -> None:
   shutil.rmtree(path)
 
 
-def get_random_dir(path: str) -> str:
+def get_random_dir(path: str) -> tempfile.TemporaryDirectory:
   """Get a random named directory.
-
-  The caller must re-create the path received if the value
-  is used as-is.
 
   Args:
     path: The location where the temporary directory is to be
@@ -63,5 +59,4 @@ def get_random_dir(path: str) -> str:
   if not os.path.exists(path):
     os.mkdir(path)
 
-  temp_dir = tempfile.TemporaryDirectory(dir=path)
-  return temp_dir.name
+  return tempfile.TemporaryDirectory(dir=path)

--- a/salvo/src/lib/common/test_file_ops.py
+++ b/salvo/src/lib/common/test_file_ops.py
@@ -82,7 +82,7 @@ def test_delete_directory():
 def test_get_random_dir():
   temp_path = file_ops.get_random_dir('my_test_path')
   assert temp_path
-  parent_dir = os.path.dirname(temp_path)
+  parent_dir = os.path.dirname(temp_path.name)
   assert parent_dir == 'my_test_path'
 
 if __name__ == '__main__':

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -168,6 +168,30 @@ class SourceTree(object):
 
     return self._build_dir.name
 
+  def copy_source_directory(self) -> bool:
+    """Clone the original source directory.
+
+    Directories outside of the bazel build tree are read only.  We must copy
+    the source to a new location to build it.
+
+    Returns:
+      a boolean value indicating the success of the copy operation
+    """
+    self._validate()
+
+    if not self._source_repo.source_path:
+      log.debug("No source location specified.  Source may need to be cloned")
+      return False
+
+    output_directory = self.get_source_directory()
+
+    log.debug(f"Copying tree from {self._source_repo.source_path} to {output_directory}")
+    ignore_bazel = shutil.ignore_patterns('bazel-*')
+    shutil.copytree(self._source_repo.source_path, output_directory,
+                    symlinks=False, ignore=ignore_bazel)
+
+    return True
+
   def pull(self) -> bool:
     """Retrieve the code from the repository.
 

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -168,30 +168,6 @@ class SourceTree(object):
 
     return self._build_dir.name
 
-  def copy_source_directory(self) -> bool:
-    """Clone the original source directory.
-
-    Directories outside of the bazel build tree are read only.  We must copy
-    the source to a new location to build it.
-
-    Returns:
-      a boolean value indicating the success of the copy operation
-    """
-    self._validate()
-
-    if not self._source_repo.source_path:
-      log.debug("No source location specified.  Source may need to be cloned")
-      return False
-
-    output_directory = self.get_source_directory()
-
-    log.debug(f"Copying tree from {self._source_repo.source_path} to {output_directory}")
-    ignore_bazel = shutil.ignore_patterns('bazel-*')
-    shutil.copytree(self._source_repo.source_path, output_directory,
-                    symlinks=False, ignore=ignore_bazel)
-
-    return True
-
   def pull(self) -> bool:
     """Retrieve the code from the repository.
 

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -48,7 +48,7 @@ def test_source_tree_with_local_workdir():
     origin = source.get_origin()
     assert origin == "git@github.com:username/reponame.git"
 
-    cmd_params = cmd_exec.CommandParameters(cwd='/some_source_path')
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with("git remote -v", cmd_params)
 
 def test_get_origin_ssh():
@@ -68,7 +68,7 @@ def test_get_origin_ssh():
                   mock.MagicMock(return_value=remote_string)) as magic_mock:
     origin_url = source.get_origin()
 
-    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert origin_url == 'git@github.com:username/reponame.git'
@@ -90,7 +90,7 @@ def test_get_origin_https():
   with mock.patch('src.lib.cmd_exec.run_command',
                   mock.MagicMock(return_value=remote_string)) as magic_mock:
     origin_url = source.get_origin()
-    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
     assert origin_url == 'https://github.com/aws/aws-app-mesh-examples.git'
@@ -439,7 +439,7 @@ def test_source_tree_with_disk_files():
     origin = source.get_origin()
     assert origin
 
-    cmd_params = cmd_exec.CommandParameters(cwd='/tmp')
+    cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
 


### PR DESCRIPTION
This change addresses https://github.com/envoyproxy/envoy-perf/issues/90.  When creating temporary directories we use a `TemporaryDirectory` object instead of a string.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k , @landesherr