### PR TITLE
Add tests and update to increase docker module coverage

### DIFF
--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -19,3 +19,6 @@ NIGHTHAWK_EXTERNAL_TEST_DIR = ('/usr/local/bin/benchmarks/benchmarks.runfiles'
 OPT_LLVM = '/opt/llvm/bin/'
 USR_BIN = '/usr/bin'
 
+# Strings used when generating the volume mount map for a container
+MOUNT_READ_ONLY = 'ro'
+MOUNT_READ_WRITE = 'rw'

--- a/salvo/src/lib/docker/BUILD
+++ b/salvo/src/lib/docker/BUILD
@@ -37,3 +37,14 @@ py_test(
         ":docker_volume",
     ],
 )
+
+py_test(
+    name = "test_docker_volume",
+    srcs = ["test_docker_volume.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//api:schema_proto",
+        "//src/lib:constants",
+        ":docker_volume",
+    ],
+)

--- a/salvo/src/lib/docker/docker_volume.py
+++ b/salvo/src/lib/docker/docker_volume.py
@@ -8,6 +8,7 @@ import logging
 
 from google.protobuf import json_format
 from src.lib import constants
+
 import api.docker_volume_pb2 as proto_docker_volume
 
 log = logging.getLogger(__name__)
@@ -39,20 +40,20 @@ def generate_volume_config(output_dir: str, test_dir: str = '') -> dict:
   # Setup the docker socket
   properties = proto_docker_volume.VolumeProperties()
   properties.bind = constants.DOCKER_SOCKET_PATH
-  properties.mode = 'rw'
+  properties.mode = constants.MOUNT_READ_WRITE
   volume_cfg.volumes[constants.DOCKER_SOCKET_PATH].CopyFrom(properties)
 
   # Setup the output directory
   properties = proto_docker_volume.VolumeProperties()
   properties.bind = output_dir
-  properties.mode = 'rw'
+  properties.mode = constants.MOUNT_READ_WRITE
   volume_cfg.volumes[output_dir].CopyFrom(properties)
 
   # Setup the test directory
   if test_dir:
     properties = proto_docker_volume.VolumeProperties()
     properties.bind = constants.NIGHTHAWK_EXTERNAL_TEST_DIR
-    properties.mode = 'ro'
+    properties.mode = constants.MOUNT_READ_ONLY
     volume_cfg.volumes[test_dir].CopyFrom(properties)
 
   volume_json = {}

--- a/salvo/src/lib/docker/test_docker_volume.py
+++ b/salvo/src/lib/docker/test_docker_volume.py
@@ -1,0 +1,103 @@
+"""
+Test Docker volume generation
+"""
+import json
+import pytest
+import logging
+from unittest import mock
+from google.protobuf import json_format
+
+from src.lib import constants
+from src.lib.docker import docker_volume
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+def test_generate_volume_config():
+  """Verify the volume mount map can be created with no test directory
+     specified.
+  """
+  output_dir = '/tmp/random_dir_on_disk'
+  volume_map = docker_volume.generate_volume_config(output_dir)
+
+  # Verify the contents of the volume map.  Specified output
+  # paths are mounted as read/write with the same external path
+  # within the container.
+  assert volume_map
+
+  verify_required_paths(volume_map, output_dir)
+
+def test_generate_volume_config_with_test_dir():
+  """Verify the volume mount map can be created when a test directory
+     is specified.
+  """
+  output_dir = '/tmp/random_dir_on_disk'
+  test_dir = '/home/user/test_directory'
+  volume_map = docker_volume.generate_volume_config(output_dir, test_dir)
+
+  # Verify the contents of the volume map.  Specified output
+  # paths are mounted as read/write with the same external path
+  # within the container.
+  assert volume_map
+
+  verify_required_paths(volume_map, output_dir)
+
+  # Verify that the read-only test directory is in the map
+  assert test_dir in volume_map
+  test_map = volume_map[test_dir]
+  assert test_map['bind'] == constants.NIGHTHAWK_EXTERNAL_TEST_DIR
+  assert test_map['mode'] == constants.MOUNT_READ_ONLY
+
+def json_loads_side_effect(arg):
+  raise json.decoder.JSONDecodeError("json loading failed", arg, 0)
+
+@mock.patch('json.loads')
+def test_generate_volume_config_json_error(mock_json_loads):
+  """Verify that an exception is raised if the json serialization fails."""
+
+  mock_json_loads.side_effect = json_loads_side_effect
+  output_dir = '/tmp/random_dir_on_disk'
+
+  volume_map = None
+  with pytest.raises(json.decoder.JSONDecodeError) as decode_error:
+    volume_map = docker_volume.generate_volume_config(output_dir)
+
+  assert not volume_map
+  assert str(decode_error.value) == \
+      'json loading failed: line 1 column 1 (char 0)'
+
+def json_loads_side_effect_format_error(arg):
+  raise json_format.Error("Error in json format")
+
+@mock.patch('json.loads')
+def test_generate_volume_config_format_error(mock_json_loads):
+  """Verify that an exception is raised if the json serialization fails."""
+
+  mock_json_loads.side_effect = json_loads_side_effect_format_error
+  output_dir = '/tmp/random_dir_on_disk'
+
+  volume_map = None
+  with pytest.raises(json_format.Error) as format_error:
+    volume_map = docker_volume.generate_volume_config(output_dir)
+
+  assert not volume_map
+  assert str(format_error.value) == 'Error in json format'
+
+def verify_required_paths(volume_map, output_dir):
+  """Verify the required mounts in the volume map"""
+  assert constants.DOCKER_SOCKET_PATH in volume_map
+  docker_map = volume_map[constants.DOCKER_SOCKET_PATH]
+
+  assert 'bind' in docker_map
+  assert docker_map['bind'] == constants.DOCKER_SOCKET_PATH
+  assert docker_map['mode'] == constants.MOUNT_READ_WRITE
+
+  assert output_dir in volume_map
+  output_map = volume_map[output_dir]
+
+  assert output_map['bind'] == output_dir
+  assert output_map['mode'] == constants.MOUNT_READ_WRITE
+
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
This PR updates the test coverage for the docker module to near 100%

Previously we were skipping these tests due to the lack of the docker socket in CI.  We now mock the operations required to exercise the modules.

```
docker/docker_image.py                         |98.4%   127|    -   0|    -    0
docker/docker_volume.py                        | 100%    51|    -   0|    -    0
```

cc: @mum4k , @landesherr

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>