### PR TITLE
Update test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 **/*.pyc
+**/*.rej
+**/*.orig
 **/*.swp
 **/.vscode/*
 **/__pycache__/*

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -29,7 +29,7 @@ function test_salvo() {
   pushd salvo
 
   install_deps
-  bazel test //...
+  tools/coverage.sh
 
   popd
 }


### PR DESCRIPTION
This PR syncs more test changes for Salvo.  Coverage increases from 95.6% to 97.1%

Since the docker volume. module has its own tests, we remove a redundant one from the job control loader tests.

Also, as part of the test target, we run the coverage script.

cc: @mum4k, @landesherr