### PR TITLE
[Salvo] Add the builder module

### DIFF
--- a/salvo/src/lib/builder/BUILD
+++ b/salvo/src/lib/builder/BUILD
@@ -1,0 +1,68 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+licenses(["notice"])  # Apache 2
+
+package(
+  default_visibility = ["//:__subpackages__"],
+)
+
+py_library(
+    name = "bazel_setup",
+    srcs = [
+        "bazel_setup.py",
+    ],
+    deps = [
+        "//src/lib:constants",
+    ],
+)
+
+py_library(
+    name = "base_builder",
+    srcs = [
+        "base_builder.py",
+    ],
+    deps = [
+        "//api:schema_proto",
+        "//src/lib/common:file_ops",
+        "//src/lib:constants",
+        "//src/lib:shell",
+        ":bazel_setup",
+    ],
+)
+
+py_library(
+    name = "envoy_builder",
+    srcs = [
+        "envoy_builder.py",
+    ],
+    deps = [
+        "//api:schema_proto",
+        "//src/lib:shell",
+        "//src/lib:constants",
+        ":base_builder"
+    ],
+)
+
+py_test(
+  name = "test_envoy_builder",
+  srcs = [ "test_envoy_builder.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      "//src/lib:constants",
+      "//src/lib:source_tree",
+      "//src/lib:source_manager",
+      ":envoy_builder",
+  ],
+)
+
+py_test(
+  name = "test_base_builder",
+  srcs = [ "test_base_builder.py" ],
+  srcs_version = "PY3",
+  deps = [
+      "//src/lib:source_manager",
+      ":base_builder",
+  ],
+)
+

--- a/salvo/src/lib/builder/base_builder.py
+++ b/salvo/src/lib/builder/base_builder.py
@@ -1,0 +1,110 @@
+"""
+Base builder class initializing the temporary directories and
+environment variables needed to execute bazel
+"""
+import os
+import logging
+
+from src.lib import (cmd_exec, constants, source_manager)
+from src.lib.common import file_ops
+from src.lib.builder import bazel_setup
+import api.source_pb2 as proto_source
+
+log = logging.getLogger(__name__)
+
+class BaseBuilderError(Exception):
+  """An error raised from the BaseBuilder class if we encounter a
+  situation where no progress can be made
+  """
+
+class BaseBuilder():
+  """BaseBuilder class encapsulating common build methods and objects managing
+  sources.
+  """
+
+  def __init__(self, manager: source_manager.SourceManager) -> None:
+    """Initialize the builder with the location of the source and setup
+      temporary directories needed for operation.
+
+    Args:
+      manager: The SourceManager object handling the source code
+        used by this builder object
+    """
+    self._source_manager = manager
+
+    # TODO(abaptiste): Preserve the location of the source so that
+    # if nothing changes we can reuse the same disk data.  This could
+    # be considered a sandbox of sorts.
+    temp_dir = os.getenv('SALVO_HOMEDIR', constants.SALVO_TMP)
+
+    # self._cache_dir is where the bazel cache is created
+    self._cache_dir = file_ops.get_random_dir(temp_dir)
+
+    # self._build_dir is where the source is copied or checked out. This is
+    # the working directory where bazel operations are performed.  The
+    # _build_dir is set from the destination directory of the source in the
+    # source_tree object
+    self._build_dir = None
+
+    os.environ['HOME'] = self._cache_dir.name
+    log.debug(f"Using HOME={os.environ['HOME']}")
+
+    bazel_setup.setup_clang_env()
+
+  def set_build_dir(self, source_directory: str) -> None:
+    """Set the source directory where build operations take place.
+
+    Args:
+      source_directory: The location of the source being built
+    """
+    self._build_dir = source_directory
+
+  def _validate(self) -> None:
+    """A private base method verifying the source and other dependencies
+       required to build an artifact.
+
+    This method should be overridden by a derived class.
+
+    Raises:
+      NotImplementedError: if this base method is invoked.
+    """
+    raise NotImplementedError("Method should be overridden")
+
+  def _run_bazel_clean(self) -> None:
+    """Run bazel clean in the source tree directory."""
+
+    assert self._build_dir
+
+    cmd_params = cmd_exec.CommandParameters(cwd=self._build_dir)
+    cmd = "bazel clean"
+    output = cmd_exec.run_command(cmd, cmd_params)
+    log.debug(f"Clean output: {output}")
+
+  def _generate_bazel_options(self, \
+      source_id: proto_source.SourceRepository.SourceIdentity) -> str:
+    """Generate the options string that we supply to bazel when building
+      Envoy or NightHawk.
+
+    Args:
+      source_id: The identity of the source object containing the options
+        we specify to bazel
+
+    Returns:
+      A string with options supplied to bazel when compiling artifacts
+    """
+    options = []
+
+    optimized_builds = True
+
+    source_repo = self._source_manager.get_source_repository(source_id)
+    bazel_options = source_repo.bazel_options
+    for option in bazel_options:
+      if option.parameter not in options:
+        options.append(option.parameter)
+      if optimized_builds and option.parameter.startswith("-c"):
+        optimized_builds = False
+
+    if optimized_builds:
+      options.append("-c opt")
+
+    return " ".join(options)

--- a/salvo/src/lib/builder/bazel_setup.py
+++ b/salvo/src/lib/builder/bazel_setup.py
@@ -1,0 +1,33 @@
+"""
+This module sets up environment variables required to execute bazel salvo.
+"""
+import os
+
+from src.lib import constants
+
+def get_clang_dir() -> str:
+  """Return the directory prefix where clang resides.
+
+  For now we return a static path.  More is needed here to discover the real
+  location since clang can live in /opt/llvm/bin as well.
+
+  Returns:
+    a string with the directory prefix where clang appears
+  """
+  paths = [constants.OPT_LLVM, constants.USR_BIN]
+  for path in paths:
+    if os.path.exists(os.path.join(path, 'clang')):
+      return path
+
+  return ''
+
+def setup_clang_env() -> None:
+  """Set the environment variables to use clang as a compiler."""
+
+  # Use CC from the environment if specified. If not, use clang
+  # TODO: We need additional sanity checks to ensure that the binaries
+  #       we are trying to use exist and fail fast if they are absent.
+  if any(['CC' not in os.environ, 'CXX' not in os.environ]):
+    clang_dir = get_clang_dir()
+    os.environ['CC'] = os.path.join(clang_dir, 'clang')
+    os.environ['CXX'] = os.path.join(clang_dir, 'clang++')

--- a/salvo/src/lib/builder/envoy_builder.py
+++ b/salvo/src/lib/builder/envoy_builder.py
@@ -1,0 +1,84 @@
+"""
+Module to build an Envoy docker image from a source directory
+"""
+
+import glob
+import os
+import logging
+
+from src.lib import (cmd_exec, constants, source_manager)
+from src.lib.builder import base_builder
+import api.source_pb2 as proto_source
+
+log = logging.getLogger(__name__)
+
+
+class EnvoyBuilderError(Exception):
+  """An error raised when an unrecoverable situation occurs while
+     building Envoy components.
+  """
+
+class EnvoyBuilder(base_builder.BaseBuilder):
+  """This class encapsulates the logic to build the envoy binary
+     and container image from source.
+  """
+
+  def __init__(self, manager: source_manager.SourceManager) -> None:
+    """Initialize the builder with the location of the source and the
+       commit hash at which we are operating.
+
+    Args:
+      manager: The source manager object handling the source needed
+        to build Envoy
+    """
+    pass
+
+  def _validate(self) -> None:
+    """Validate the identity of the source defined from which Envoy is
+    built.
+    """
+    pass
+
+  def clean_envoy(self) -> None:
+    """Remove all build artifacts."""
+    pass
+
+  def build_envoy(self) -> None:
+    """Run bazel build to generate the envoy-static binary."""
+    pass
+
+  def build_envoy_image_from_source(self) -> None:
+    """Build an Envoy docker image from source.
+
+    This method performs a few steps. It compiles the envoy binary,
+    stages it for inclusion in a docker image, and builds the docker
+    image.
+
+    Returns:
+      None
+    """
+    pass
+
+  def stage_envoy(self, strip_binary: bool) -> None:
+    """Copy and optionally strip the Envoy binary.
+
+    Args:
+      strip_binary: determines whether we use objcopy to strip debug
+        symbols from the envoy binary. If strip_binary is False, we
+        simply copy the binary to its destination
+
+        Callers use False for now, until we expose a control for
+        manipulating this parameter.
+
+    Returns:
+      None
+    """
+    pass
+
+  def _generate_docker_ignore(self) -> None:
+    """Generate a dockerignore file to reduce the context size."""
+    pass
+
+  def create_docker_image(self) -> None:
+    """Build a docker image with the newly compiled Envoy binary."""
+    pass

--- a/salvo/src/lib/builder/test_base_builder.py
+++ b/salvo/src/lib/builder/test_base_builder.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src.lib import source_manager
+from src.lib.builder import base_builder
+
+import api.control_pb2 as proto_control
+import api.source_pb2 as proto_source
+
+class DerivedBuilder(base_builder.BaseBuilder):
+  def __init__(self, manager: source_manager.SourceManager):
+    super(DerivedBuilder, self).__init__(manager)
+    pass
+
+  def do_something(self):
+    self._validate()
+
+def test_validate_must_be_overidden():
+  """Verify that the base _validate method must be overridden and raises
+  an exception otherwise.
+  """
+  control = proto_control.JobControl(remote=False, scavenging_benchmark=True)
+  control.source.add(
+      identity=proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
+      source_path='/some_random_envoy_directory',
+  )
+  manager = source_manager.SourceManager(control)
+  builder = DerivedBuilder(manager)
+
+  with pytest.raises(NotImplementedError) as not_implemented:
+    builder.do_something()
+
+  assert str(not_implemented.value) == "Method should be overridden"
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -1,0 +1,47 @@
+"""
+Test envoy building operations
+"""
+import logging
+import pytest
+from unittest import mock
+
+import api.source_pb2 as proto_source
+import api.control_pb2 as proto_control
+from src.lib.builder import envoy_builder
+from src.lib import (constants, source_tree, source_manager)
+
+logging.basicConfig(level=logging.DEBUG)
+
+def test_build_envoy_image_from_source():
+  """Verify the calls made to build an envoy image from a source tree."""
+  pass
+
+def test_build_envoy_image_from_source_fail():
+  """Verify an exception is raised if the source identity is invalid"""
+  pass
+
+def test_stage_envoy():
+  """Verify the commands used to stage the envoy binary for docker image
+  construction.
+  """
+  pass
+
+def test_create_docker_image():
+  """Verify that we issue the correct commands to build an envoy docker
+  image.
+  """
+  pass
+
+def _generate_default_source_manager():
+  """Build a default SourceRepository object."""
+
+  control = proto_control.JobControl(remote=False, scavenging_benchmark=True)
+  control.source.add(
+      identity=proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
+      source_path='/some_random_envoy_directory',
+      commit_hash='v1.16.0'
+  )
+  return source_manager.SourceManager(control)
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
This PR adds the builder module into Salvo.  In the builder module we have classes that encapsulate the steps needed to build Envoy and NightHawk from source.

We have a skeleton implementation here, including the unit tests so that we maintain the test coverage level.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k, @landesherr