### PR TITLE
[Salvo] Add the implementation of the envoy builder

### DIFF
--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -12,25 +12,120 @@ from src.lib import (constants, source_tree, source_manager)
 
 logging.basicConfig(level=logging.DEBUG)
 
-def test_build_envoy_image_from_source():
+def _check_call_side_effect(args, parameters):
+  """Examine the incoming arguments for command execution and return the
+  expected or unexpected output.
+
+  Args:
+    args: The arguments supplied to the mocked function
+    parameter: The CommandParameters passed to the cmd_exec method
+  Return:
+    usually this returns a string containing the command output.  In
+      some cases we may raise an exception.
+  """
+
+  assert 'cwd' in parameters._asdict()
+
+  if args == "bazel clean":
+    return "INFO: Starting clean"
+  elif args == "bazel build -c opt " + constants.ENVOY_BINARY_BUILD_TARGET:
+    return "foo"
+  elif args == ("cp -fv bazel-bin/source/exe/envoy-static "
+                "build_release_stripped/envoy"):
+    return "copied..."
+  elif args == (("objcopy --strip-debug bazel-bin/source/exe/envoy-static "
+                 "build_release_stripped/envoy")):
+    return "stripped..."
+  elif args == (("docker build -f ci/Dockerfile-envoy -t "
+                 "envoyproxy/envoy-dev:v1.16.0 --build-arg "
+                 "TARGETPLATFORM='.' .")):
+    return "docker build output..."
+
+  raise NotImplementedError(f"Unhandled arguments in call: {args}")
+
+@mock.patch.object(envoy_builder.EnvoyBuilder, 'create_docker_image')
+@mock.patch.object(envoy_builder.EnvoyBuilder, 'stage_envoy')
+@mock.patch('src.lib.cmd_exec.run_check_command')
+@mock.patch('src.lib.cmd_exec.run_command')
+@mock.patch.object(source_tree.SourceTree, 'checkout_commit_hash')
+@mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
+def test_build_envoy_image_from_source(mock_copy_source,
+                                       mock_checkout_hash,
+                                       mock_run_command,
+                                       mock_run_check_command,
+                                       mock_stage_envoy,
+                                       mock_create_docker_image):
   """Verify the calls made to build an envoy image from a source tree."""
-  pass
+  mock_copy_source.return_value = None
+  mock_checkout_hash.return_value = None
+  mock_run_command.side_effect = _check_call_side_effect
+  mock_run_check_command.side_effect = _check_call_side_effect
+  mock_stage_envoy.return_value = None
+  mock_create_docker_image.return_value = None
 
-def test_build_envoy_image_from_source_fail():
+  manager = _generate_default_source_manager()
+  builder = envoy_builder.EnvoyBuilder(manager)
+  builder.build_envoy_image_from_source()
+
+  mock_copy_source.assert_called_once()
+  mock_checkout_hash.assert_called_once()
+  mock_stage_envoy.assert_called_once_with(False)
+  mock_create_docker_image.assert_called_once()
+
+@mock.patch.object(source_manager.SourceManager, 'get_source_repository')
+def test_build_envoy_image_from_source_fail(mock_get_source_tree):
   """Verify an exception is raised if the source identity is invalid"""
-  pass
 
-def test_stage_envoy():
+  nighthawk_source_repo = proto_source.SourceRepository(
+      identity=proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK,
+      source_path='/some_random_not_envoy_directory'
+  )
+
+  mock_get_source_tree.return_value = nighthawk_source_repo
+  manager = _generate_default_source_manager()
+  builder = envoy_builder.EnvoyBuilder(manager)
+
+  with pytest.raises(envoy_builder.EnvoyBuilderError) as builder_error:
+    builder.build_envoy_image_from_source()
+
+  assert str(builder_error.value) == "This class builds Envoy only."
+
+@mock.patch('src.lib.cmd_exec.run_command')
+def test_stage_envoy(mock_run_command):
   """Verify the commands used to stage the envoy binary for docker image
   construction.
   """
-  pass
+  mock_run_command.side_effect = _check_call_side_effect
 
-def test_create_docker_image():
+  calls = [
+    mock.call(("cp -fv bazel-bin/source/exe/envoy-static "
+              "build_release_stripped/envoy"),
+              mock.ANY),
+    mock.call(("objcopy --strip-debug bazel-bin/source/exe/envoy-static "
+              "build_release_stripped/envoy"),
+              mock.ANY)
+  ]
+  manager = _generate_default_source_manager()
+  builder = envoy_builder.EnvoyBuilder(manager)
+  builder.stage_envoy(False)
+  builder.stage_envoy(True)
+
+  mock_run_command.assert_has_calls(calls)
+
+@mock.patch('glob.glob')
+@mock.patch('src.lib.cmd_exec.run_command')
+def test_create_docker_image(mock_run_command, mock_glob):
   """Verify that we issue the correct commands to build an envoy docker
   image.
   """
-  pass
+  mock_run_command.side_effect = _check_call_side_effect
+  mock_glob.return_value = ['file1', 'file2']
+
+  manager = _generate_default_source_manager()
+  builder = envoy_builder.EnvoyBuilder(manager)
+  builder.create_docker_image()
+
+  mock_run_command.assert_called_once()
 
 def _generate_default_source_manager():
   """Build a default SourceRepository object."""

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -32,8 +32,8 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
       The output produced by the command
 
   Raises:
-    subprocess.CalledProcessError if there was a failure executing the specified
-      command
+    subprocess.CalledProcessError: if the command exits with a non-zero exit
+      code
   """
 
   # Because the stdout/stderr from nighthawk can be large, we redirect it to
@@ -71,8 +71,7 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
   return output
 
 def run_check_command(cmd: str, parameters: CommandParameters) -> None:
-  """Run the specified command checking its exit status. If the command exits
-     with a non-zero return code an exception is raised.
+  """Run the specified command checking its exit status.
 
   Args:
       cmd: The command to be executed
@@ -83,8 +82,8 @@ def run_check_command(cmd: str, parameters: CommandParameters) -> None:
         execution.
 
   Raises:
-    subprocess.CalledProcessError if there was a failure executing the specified
-      command
+    subprocess.CalledProcessError: if the command exits with a non-zero exit
+      code
   """
   try:
     log.debug(f"Executing command: [{cmd}] with args [{parameters._asdict()}]")

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -70,3 +70,28 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
 
   return output
 
+def run_check_command(cmd: str, parameters: CommandParameters) -> None:
+  """Run the specified command checking its exit status. If the command exits
+     with a non-zero return code an exception is raised.
+
+  Args:
+      cmd: The command to be executed
+      parameters: Additional arguments provided to check_output. Most
+        importantly, we specify 'cwd' which is the intended working directory
+        where the command is to be executed.  Other parameters supported
+        by the subprocess module will be added as they become necessary for
+        execution.
+
+  Raises:
+    subprocess.CalledProcessError if there was a failure executing the specified
+      command
+  """
+  try:
+    log.debug(f"Executing command: [{cmd}] with args [{parameters._asdict()}]")
+    cmd_array = shlex.split(cmd)
+    subprocess.check_call(
+        cmd_array, stderr=subprocess.STDOUT, **parameters._asdict())
+
+  except subprocess.CalledProcessError as process_error:
+    log.error(f"Unable to execute [{cmd}]: {process_error}")
+    raise

--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -22,3 +22,9 @@ USR_BIN = '/usr/bin'
 # Strings used when generating the volume mount map for a container
 MOUNT_READ_ONLY = 'ro'
 MOUNT_READ_WRITE = 'rw'
+
+# Define the well known build target for the envoy-static binary
+ENVOY_BINARY_BUILD_TARGET = "//source/exe:envoy-static"
+
+# Define the location of the compiled envoy-static binary
+ENVOY_BINARY_TARGET_OUTPUT_PATH = "bazel-bin/source/exe/envoy-static"


### PR DESCRIPTION
In this PR we add the implementation for the skeleton upstreamed earlier. 

We add additional changes in existing modules.  Most notably is cmd_exec, we add a second method to execute a command where we are only interested in whether the command exits successfully.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k, @landesherr