### PR TITLE
[Salvo] Linter and bug fixes

### DIFF
--- a/salvo/src/lib/benchmark/BUILD
+++ b/salvo/src/lib/benchmark/BUILD
@@ -34,6 +34,7 @@ py_test(
   deps = [
       "//api:schema_proto",
       "//src/lib/docker:docker_image",
+      "//src/lib:constants",
       ":benchmark"
   ],
 )

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -2,7 +2,6 @@
 Test the fully dockerized benchmark class
 """
 
-import os
 import pytest
 from unittest import mock
 
@@ -27,9 +26,9 @@ def _generate_images(
   generated_images.nighthawk_benchmark_image = \
       "envoyproxy/nighthawk-benchmark-dev:random_benchmark_image_tag"
   generated_images.nighthawk_binary_image = \
-      "envoyproxy/nighthawk-dev:random-binary_image_tag"
+      "envoyproxy/nighthawk-dev:random_binary_image_tag"
   generated_images.envoy_image = \
-      "envoyproxy/envoy-dev:f61b096f6a2dd3a9c74b9a9369a6ea398dbe1f0f"
+      "envoyproxy/envoy-dev:random_envoy_image_hash"
 
   return generated_images
 
@@ -54,12 +53,12 @@ def _generate_envoy_source(
   Returns:
     a SourceRepository object defining the location of the Envoy source.
   """
-  envoy_source = job_control.source.add()
-  envoy_source.identity = envoy_source.SRCID_ENVOY
-  envoy_source.source_path = "/home/ubuntu/envoy"
-  envoy_source.source_url = "https://github.com/envoyproxy/envoy.git"
-  envoy_source.branch = "master"
-  envoy_source.commit_hash = "hash_doesnt_really_matter_here"
+  envoy_source = job_control.source.add(
+      identity=proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
+      source_url="https://github.com/envoyproxy/envoy.git",
+      branch="master",
+      commit_hash="hash_doesnt_really_matter_here"
+  )
 
   return envoy_source
 
@@ -71,8 +70,8 @@ def _generate_default_job_control() -> proto_control.JobControl:
   )
   return job_control
 
-def test_images_only_config():
-  """Test benchmark validation logic."""
+def test_execute_benchmark_using_images_only():
+  """Validate we execute the benchmark with only images specified."""
 
   # create a valid configuration defining images only for benchmark
   job_control = _generate_default_job_control()
@@ -93,17 +92,15 @@ def test_images_only_config():
   # Calling execute_benchmark shoud not throw an exception
   # Mock the container invocation so that we don't try to pull an image
   with mock.patch('src.lib.benchmark.base_benchmark.BaseBenchmark.run_image') \
-      as docker_mock:
+      as benchmark_run_image_mock:
     benchmark.execute_benchmark()
-    docker_mock.assert_called_once_with(
+    benchmark_run_image_mock.assert_called_once_with(
         'envoyproxy/nighthawk-benchmark-dev:random_benchmark_image_tag',
         run_parameters)
 
-def test_no_envoy_image_no_sources():
-  """Test benchmark validation logic.
-
-  No Envoy image is specified, we expect the validation logic to
-  throw an exception since no sources are present
+def test_execute_benchmark_no_image_or_sources():
+  """Verify that the validation logic raises an exception since we are unable to
+  build a required Envoy image.
   """
   # create a valid configuration with a missing Envoy image
   job_control = _generate_default_job_control()
@@ -122,11 +119,9 @@ def test_no_envoy_image_no_sources():
 
   assert str(validation_error.value) == "No source configuration specified"
 
-def test_source_to_build_envoy():
-  """Validate we can build images from source.
-
-  Validate that sources are defined that enable us to build the Envoy image
-  We do not expect the validation logic to throw an exception
+def test_execute_benchmark_with_envoy_source():
+  """Validate that if sources are defined that enable us to build the Envoy
+  image we do not throw an exception.
   """
   # create a valid configuration with a missing Envoy image
   job_control = _generate_default_job_control()
@@ -135,12 +130,7 @@ def test_source_to_build_envoy():
   images.envoy_image = ""
 
   _generate_envoy_source(job_control)
-
-  env = job_control.environment
-  env.test_version = env.IPV_V4ONLY
-  env.envoy_path = 'envoy'
-  env.output_dir = 'some_output_dir'
-  env.test_dir = 'some_test_dir'
+  _generate_environment(job_control)
 
   benchmark = full_docker.Benchmark(job_control, "test_benchmark")
 
@@ -160,13 +150,9 @@ def test_source_to_build_envoy():
         'envoyproxy/nighthawk-benchmark-dev:random_benchmark_image_tag',
         run_parameters)
 
-def test_no_source_to_build_envoy():
-  """Validate that we fail to build images without sources.
-
-  Validate that no sources are present that enable us to build the missing
-  Envoy image
-
-  We expect the validation logic to throw an exception
+def test_execute_benchmark_missing_envoy_source():
+  """Validate that although sources are defined for NightHawk we raise an
+  exception due to the inability to build Envoy.
   """
   # create a configuration with a missing Envoy image
   job_control = proto_control.JobControl(
@@ -177,28 +163,22 @@ def test_no_source_to_build_envoy():
   images = _generate_images(job_control)
   images.envoy_image = ""
 
-  # Denote that the soure is for nighthawk.  Values aren't really checked at
-  # this stage since we have a missing Envoy image and a nighthawk source
-  # validation should fail.
+  # Change the source identity to NightHawk
   envoy_source = _generate_envoy_source(job_control)
   envoy_source.identity = envoy_source.SRCID_NIGHTHAWK
 
   benchmark = full_docker.Benchmark(job_control, "test_benchmark")
 
-  # Calling execute_benchmark shoud not throw an exception
+  # Calling execute_benchmark should raise an exception from validate()
   with pytest.raises(Exception) as validation_exception:
     benchmark.execute_benchmark()
 
   assert str(validation_exception.value) == \
       "No source specified to build unspecified Envoy image"
 
-def test_no_source_to_build_nh():
-  """Validate that we fail to build nighthawk without sources.
-
-  Validate that no sources are defined that enable us to build the missing
-  NightHawk benchmark image.
-
-  We expect the validation logic to throw an exception
+def test_execute_benchmark_missing_nighthawk_binary_image():
+  """Validate that no sources are defined that enable us to build the missing
+  NightHawk benchmark image resulting in a raised exception.
   """
   # create a valid configuration with a missing NightHawk container image
   job_control = proto_control.JobControl(
@@ -209,27 +189,20 @@ def test_no_source_to_build_nh():
   images = _generate_images(job_control)
   images.nighthawk_binary_image = ""
 
-  # Generate a default Envoy source object.  Values aren't really checked at
-  # this stage since we have a missing Envoy image, nighthawk source validation
-  # should fail.
+  # Generate a default Envoy source object.
   _generate_envoy_source(job_control)
-
   benchmark = full_docker.Benchmark(job_control, "test_benchmark")
 
-  # Calling execute_benchmark shoud not throw an exception
+  # Calling execute_benchmark raise an exception from validate()
   with pytest.raises(Exception) as validation_exception:
     benchmark.execute_benchmark()
 
   assert str(validation_exception.value) == \
       "No source specified to build unspecified NightHawk image"
 
-def test_no_source_to_build_nh2():
-  """Validate that we fail to build nighthawk without sources.
-
-  Validate that no sources are defined that enable us to build the missing
-  NightHawk binary image.
-
-  We expect the validation logic to throw an exception
+def test_execute_benchmark_missing_nighthawk_benchmark_image():
+  """Validate an exception is raised if we cannot build the unspecified
+  NightHawk benchmark image.
   """
   # create a valid configuration with a missing both NightHawk container images
   job_control = proto_control.JobControl(
@@ -238,12 +211,9 @@ def test_no_source_to_build_nh2():
   )
 
   images = _generate_images(job_control)
-  images.nighthawk_binary_image = ""
   images.nighthawk_benchmark_image = ""
 
-  # Generate a default Envoy source object.  Values aren't really checked at
-  # this stage since we have a missing Envoy image, nighthawk source validation
-  # should fail.
+  # Generate a default Envoy source object
   _generate_envoy_source(job_control)
 
   benchmark = full_docker.Benchmark(job_control, "test_benchmark")
@@ -254,7 +224,6 @@ def test_no_source_to_build_nh2():
 
   assert str(validation_exception.value) == \
       "No source specified to build unspecified NightHawk image"
-
 
 if __name__ == '__main__':
   raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/test_fully_dockerized_benchmark.py
@@ -13,6 +13,7 @@ import api.source_pb2 as proto_source
 from src.lib.benchmark import fully_dockerized_benchmark as full_docker
 from src.lib.benchmark import base_benchmark
 from src.lib.docker import docker_image
+from src.lib import constants
 
 def _generate_images(
     job_control: proto_control.JobControl) -> proto_image.DockerImages:
@@ -55,7 +56,7 @@ def _generate_envoy_source(
   """
   envoy_source = job_control.source.add(
       identity=proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
-      source_url="https://github.com/envoyproxy/envoy.git",
+      source_url=constants.ENVOY_GITHUB_REPO,
       branch="master",
       commit_hash="hash_doesnt_really_matter_here"
   )

--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -1,7 +1,6 @@
 """
 Test envoy building operations
 """
-import logging
 import pytest
 from unittest import mock
 
@@ -9,8 +8,6 @@ import api.source_pb2 as proto_source
 import api.control_pb2 as proto_control
 from src.lib.builder import envoy_builder
 from src.lib import (constants, source_tree, source_manager)
-
-logging.basicConfig(level=logging.DEBUG)
 
 def _check_call_side_effect(args, parameters):
   """Examine the incoming arguments for command execution and return the

--- a/salvo/src/lib/builder/test_nighthawk_builder.py
+++ b/salvo/src/lib/builder/test_nighthawk_builder.py
@@ -1,7 +1,6 @@
 """
 Test envoy building operations
 """
-import logging
 import pytest
 from unittest import mock
 
@@ -9,8 +8,6 @@ import api.source_pb2 as proto_source
 import api.control_pb2 as proto_control
 from src.lib.builder import nighthawk_builder
 from src.lib import (cmd_exec, constants, source_tree, source_manager)
-
-logging.basicConfig(level=logging.DEBUG)
 
 @mock.patch.object(source_manager.SourceManager, 'get_source_repository')
 def test_prepare_nighthawk_source_fail(mock_get_source_tree):

--- a/salvo/src/lib/constants.py
+++ b/salvo/src/lib/constants.py
@@ -33,3 +33,7 @@ ENVOY_BINARY_BUILD_TARGET = "//source/exe:envoy-static"
 
 # Define the location of the compiled envoy-static binary
 ENVOY_BINARY_TARGET_OUTPUT_PATH = "bazel-bin/source/exe/envoy-static"
+
+# Define the default locations of NightHawk and Envoy
+NIGHTHAWK_GITHUB_REPO = 'https://github.com/envoyproxy/nighthawk.git'
+ENVOY_GITHUB_REPO = 'https://github.com/envoyproxy/envoy.git'

--- a/salvo/src/lib/docker/test_docker_volume.py
+++ b/salvo/src/lib/docker/test_docker_volume.py
@@ -3,15 +3,11 @@ Test Docker volume generation
 """
 import json
 import pytest
-import logging
 from unittest import mock
 from google.protobuf import json_format
 
 from src.lib import constants
 from src.lib.docker import docker_volume
-
-logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger(__name__)
 
 def test_generate_volume_config():
   """Verify the volume mount map can be created with no test directory

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -4,7 +4,7 @@ This module abstracts the higher level functions of managing source code
 import logging
 from typing import Set
 
-from src.lib import source_tree
+from src.lib import (constants, source_tree)
 
 import api.source_pb2 as proto_source
 import api.control_pb2 as proto_control
@@ -16,9 +16,9 @@ log = logging.getLogger(__name__)
 """
 _KNOWN_REPOSITORIES = {
     proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY: \
-      'https://github.com/envoyproxy/envoy.git',
+      constants.ENVOY_GITHUB_REPO,
     proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK: \
-      'https://github.com/envoyproxy/nighthawk.git'
+      constants.NIGHTHAWK_GITHUB_REPO
 }
 
 

--- a/salvo/src/lib/test_cmd_exec.py
+++ b/salvo/src/lib/test_cmd_exec.py
@@ -1,7 +1,6 @@
 import pytest
 import subprocess
 from unittest import mock
-import unittest
 from src.lib import cmd_exec
 
 
@@ -61,6 +60,24 @@ def test_run_command_fail(mock_check_call):
   output = ''
   with pytest.raises(subprocess.CalledProcessError) as process_error:
     output = cmd_exec.run_command(cmd, cmd_parameters)
+
+  assert not output
+  assert f"Command \'{cmd}\' returned non-zero exit status" in \
+    str(process_error.value)
+
+@mock.patch('subprocess.check_call')
+def test_run_check_command_fail(mock_check_call):
+  """Verify that a CalledProcessError is bubbled to the caller if the command
+  fails.
+  """
+  mock_check_call.side_effect = check_call_side_effect
+
+  cmd_parameters = cmd_exec.CommandParameters(cwd='/tmp')
+  cmd = 'command_error'
+
+  output = ''
+  with pytest.raises(subprocess.CalledProcessError) as process_error:
+    output = cmd_exec.run_check_command(cmd, cmd_parameters)
 
   assert not output
   assert f"Command \'{cmd}\' returned non-zero exit status" in \

--- a/salvo/src/lib/test_job_control_loader.py
+++ b/salvo/src/lib/test_job_control_loader.py
@@ -7,12 +7,10 @@ import tempfile
 import pytest
 
 from google.protobuf import json_format
-from src.lib import constants
 from src.lib import job_control_loader as job_ctrl
 
 import api.control_pb2 as proto_control
 import api.source_pb2 as proto_source
-import api.docker_volume_pb2 as proto_docker_volume
 
 
 def _write_object_to_disk(pb_obj, path):

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -1,16 +1,12 @@
 """
 Test source management operations needed for executing benchmarks
 """
-import logging
 import pytest
 from unittest import mock
 
 from src.lib import (source_manager, source_tree)
 import api.control_pb2 as proto_control
 import api.source_pb2 as proto_source
-
-logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger(__name__)
 
 def _verify_cwd(**kwargs):
   """Verify cwd is defined in kwargs."""

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -3,14 +3,11 @@ Test source_tree operations needed for executing benchmarks
 """
 from unittest import mock
 import pytest
-import logging
 import subprocess
 
 from src.lib import (cmd_exec, source_tree, constants)
-import api.source_pb2 as proto_source
 
-logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger(__name__)
+import api.source_pb2 as proto_source
 
 def test_is_tag():
   """Verify that we can detect a hash and a git tag."""
@@ -24,18 +21,17 @@ def test_get_identity():
   """Verify we can retrieve the identity out of a source repository object."""
 
   for source_id in [
-    proto_source.SourceRepository.SourceIdentity.SRCID_UNSPECIFIED,
-    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
-    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK,
+      proto_source.SourceRepository.SourceIdentity.SRCID_UNSPECIFIED,
+      proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY,
+      proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK,
   ]:
     source_repository = proto_source.SourceRepository(
-      identity=source_id
+        identity=source_id
     )
 
     tree = source_tree.SourceTree(source_repository)
     identity = tree.get_identity()
     assert identity == source_id
-
 
 def test_source_tree_object():
   """Verify that we throw an exception if not all required data is present."""
@@ -83,7 +79,7 @@ def test_get_origin_ssh(mock_get_source_directory):
   In this instance the repo was cloned via ssh.
   """
 
-  mock_get_source_directory.return_value='/some_temp_directory'
+  mock_get_source_directory.return_value = '/some_temp_directory'
 
   remote_string = 'origin  git@github.com:username/reponame.git (fetch)'
   git_cmd = "git remote -v"
@@ -109,7 +105,7 @@ def test_get_origin_https(mock_get_source_directory):
   In this instance the repo was cloned via https
   """
 
-  mock_get_source_directory.return_value='/some_temp_directory'
+  mock_get_source_directory.return_value = '/some_temp_directory'
 
   remote_string = \
       'origin	https://github.com/aws/aws-app-mesh-examples.git (fetch)'
@@ -206,10 +202,10 @@ def mock_run_command_side_effect(*function_args):
       "git rev-list --no-merges "
       "--committer=\'GitHub <noreply@github.com>\' "
       "--max-count=2 invalid_hash_reference"):
-    git_output = """fatal: ambiguous argument 'invalid_hash_reference': unknown revision or path not in the working tree.
-Use '--' to separate paths from revisions, like this:
-'git <command> [<revision>...] -- [<file>...]'
-"""
+    git_output = ("fatal: ambiguous argument 'invalid_hash_reference': "
+                  "unknown revision or path not in the working tree.\n"
+                  "Use '--' to separate paths from revisions, like this:\n"
+                  "git <command> [<revision>...] -- [<file>...]")
     return git_output
 
   elif function_args[0] == (
@@ -430,7 +426,6 @@ def testget_revs_behind_parent_branch_up_to_date():
   git_cmd = 'git status'
   git_output = """On branch master
 Your branch is up to date with 'origin/master'.
-
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
   (use "git checkout -- <file>..." to discard changes in working directory)
@@ -495,7 +490,7 @@ v1.16.0
   source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'
-  previous_tag = 'v1.15.2'
+  expected_tag = 'v1.15.2'
 
   git_cmd = "git tag --list --sort v:refname"
 
@@ -506,7 +501,7 @@ v1.16.0
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
-    assert previous_tag == previous_tag
+    assert expected_tag == previous_tag
 
 
 def test_get_previous_tag_fail():
@@ -542,7 +537,7 @@ v1.16.0
   source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'
-  previous_tag = 'v1.14.5'
+  expected_tag = 'v1.14.5'
 
   git_cmd = "git tag --list --sort v:refname"
 
@@ -554,7 +549,7 @@ v1.16.0
     cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
     magic_mock.assert_called_once_with(git_cmd, cmd_params)
 
-    assert previous_tag == previous_tag
+    assert expected_tag == previous_tag
 
 def test_source_tree_with_disk_files():
   """Verify that we can get hash data from a source tree on disk."""


### PR DESCRIPTION
In this PR we address some lingering linter issues and include a few bug fixes

1.  Linter changes include line length fixes, indentation fixes, and import cleanup.
2. We remove the logging import and logger configuration from unit tests
3. Fixed a bug where `shutil.copytree` conflicts with our use of temporary directories.
4. Fixed a bug in the source tree tests where we were comparing a variable to itself.
5. Moving common used strings into `constants` and to module global variables in the source tree tests.

No new features are added in this PR, and coverage is at 97.7%

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k , @landesherr