### PR TITLE
[Salvo] No new features cleanup and a minor bugfix.

### DIFF
--- a/salvo/BUILD
+++ b/salvo/BUILD
@@ -8,7 +8,7 @@ py_binary(
     srcs_version = "PY3",
     deps = [
         "//api:schema_proto",
-        "//src/lib:job_control",
+        "//src/lib:job_control_loader",
     ],
 )
 

--- a/salvo/src/lib/BUILD
+++ b/salvo/src/lib/BUILD
@@ -7,7 +7,7 @@ package(
 )
 
 py_library(
-    name = "job_control",
+    name = "job_control_loader",
     srcs = [
         "job_control_loader.py",
     ],
@@ -32,9 +32,9 @@ py_test(
     srcs = ["test_job_control_loader.py"],
     srcs_version = "PY3",
     deps = [
-        ":constants",
-        ":job_control",
         "//api:schema_proto",
+        ":constants",
+        ":job_control_loader",
     ],
 )
 
@@ -57,6 +57,7 @@ py_library(
         "source_manager.py",
     ],
     deps = [
+        ":constants",
         ":source_tree",
     ],
 )

--- a/salvo/src/lib/builder/BUILD
+++ b/salvo/src/lib/builder/BUILD
@@ -26,6 +26,7 @@ py_library(
         "//src/lib/common:file_ops",
         "//src/lib:constants",
         "//src/lib:shell",
+        "//src/lib:source_manager",
         ":bazel_setup",
     ],
 )

--- a/salvo/src/lib/builder/test_base_builder.py
+++ b/salvo/src/lib/builder/test_base_builder.py
@@ -9,7 +9,6 @@ import api.source_pb2 as proto_source
 class DerivedBuilder(base_builder.BaseBuilder):
   def __init__(self, manager: source_manager.SourceManager):
     super(DerivedBuilder, self).__init__(manager)
-    pass
 
   def do_something(self):
     self._validate()

--- a/salvo/src/lib/builder/test_nighthawk_builder.py
+++ b/salvo/src/lib/builder/test_nighthawk_builder.py
@@ -9,6 +9,8 @@ import api.control_pb2 as proto_control
 from src.lib.builder import nighthawk_builder
 from src.lib import (cmd_exec, constants, source_tree, source_manager)
 
+_bazel_clean_cmd = "bazel clean"
+
 @mock.patch.object(source_manager.SourceManager, 'get_source_repository')
 def test_prepare_nighthawk_source_fail(mock_get_source_tree):
   """Verify an exception is raised if the source identity is invalid"""
@@ -48,7 +50,7 @@ def test_prepare_nighthawk_source(mock_pull, mock_copy_source,
     builder.prepare_nighthawk_source()
 
   params = cmd_exec.CommandParameters(cwd='/tmp/nighthawk_source_dir')
-  mock_cmd.assert_called_once_with("bazel clean", params)
+  mock_cmd.assert_called_once_with(_bazel_clean_cmd, params)
   mock_pull.assert_called_once()
   mock_copy_source.assert_called_once()
 
@@ -66,7 +68,7 @@ def test_build_nighthawk_benchmarks(mock_pull, mock_copy_source,
       'bazel build output ...'
   ]
   calls = [
-      mock.call("bazel clean", mock.ANY),
+      mock.call(_bazel_clean_cmd, mock.ANY),
       mock.call("bazel build --jobs 4 -c opt //benchmarks:benchmarks", mock.ANY)
   ]
 
@@ -97,7 +99,7 @@ def test_build_nighthawk_binaries(mock_pull, mock_copy_source,
       'bazel nighthawk build output ...'
   ]
   calls = [
-      mock.call("bazel clean", mock.ANY),
+      mock.call(_bazel_clean_cmd, mock.ANY),
       mock.call("bazel build --jobs 4 -c dbg //:nighthawk", mock.ANY)
   ]
   manager = _generate_default_source_manager()
@@ -125,7 +127,7 @@ def test_build_nighthawk_benchmark_image(mock_pull, mock_run_command):
       'bazel benchmark image build output ...'
   ]
   calls = [
-      mock.call("bazel clean", mock.ANY),
+      mock.call(_bazel_clean_cmd, mock.ANY),
       mock.call("bazel build -c opt //benchmarks:benchmarks", mock.ANY),
       mock.call(constants.NH_BENCHMARK_IMAGE_SCRIPT, mock.ANY)
   ]
@@ -149,7 +151,7 @@ def test_build_nighthawk_binary_image(mock_pull, mock_run_command):
       'bazel benchmark image build output ...'
   ]
   calls = [
-      mock.call("bazel clean", mock.ANY),
+      mock.call(_bazel_clean_cmd, mock.ANY),
       mock.call("bazel build -c opt //:nighthawk", mock.ANY),
       mock.call(constants.NH_BINARY_IMAGE_SCRIPT, mock.ANY)
   ]

--- a/salvo/src/lib/common/BUILD
+++ b/salvo/src/lib/common/BUILD
@@ -6,9 +6,8 @@ package(
 
 py_library(
     name = "file_ops",
-    data = [
-        "file_ops.py",
-    ],
+    srcs = [ "file_ops.py" ],
+    srcs_version = "PY3",
 )
 
 py_test(

--- a/salvo/src/lib/common/test_file_ops.py
+++ b/salvo/src/lib/common/test_file_ops.py
@@ -61,7 +61,7 @@ def test_open_yaml_as_json():
       temp_data.write(_TEST_YAML)
 
     with pytest.raises(json.decoder.JSONDecodeError) as decode_error:
-      json_data = file_ops.open_json(temp_json.name)
+      _ = file_ops.open_json(temp_json.name)
 
     assert 'Expecting value' in str(decode_error.value)
 

--- a/salvo/src/lib/docker/test_docker_image_builder.py
+++ b/salvo/src/lib/docker/test_docker_image_builder.py
@@ -13,6 +13,8 @@ from src.lib.builder import (envoy_builder, nighthawk_builder)
 import api.source_pb2 as proto_source
 import api.control_pb2 as proto_control
 
+_default_envoy_image_tag = "envoy/envoy-dev:envoy_tag"
+
 _generate_image_name_from_tag_mock_name = \
     'src.lib.docker.docker_image_builder.generate_envoy_image_name_from_tag'
 _build_envoy_docker_image_mock_name = \
@@ -55,7 +57,7 @@ def test_build_missing_envoy_docker_image(mock_list_images,
   are present"""
 
   mock_list_images.return_value = []
-  mock_generate_image_from_tag.return_value = "envoy/envoy-dev:envoy_tag"
+  mock_generate_image_from_tag.return_value = _default_envoy_image_tag
 
   manager = generate_image_manager_with_source_url()
   with mock.patch(_build_envoy_docker_image_mock_name,
@@ -121,12 +123,12 @@ def test_build_envoy_image_from_source(mock_build_missing_image,
   """
 
   mock_build_missing_image.return_value = None
-  mock_generate_image_from_tag.return_value = "envoy/envoy-dev:envoy_tag"
+  mock_generate_image_from_tag.return_value = _default_envoy_image_tag
 
   manager = generate_image_manager_with_source_url()
   image_tag = image_builder.build_envoy_image_from_source(manager, 'envoy_tag')
 
-  assert image_tag == "envoy/envoy-dev:envoy_tag"
+  assert image_tag == _default_envoy_image_tag
   mock_generate_image_from_tag.assert_called_once()
   mock_build_missing_image.assert_called_once_with(manager, 'envoy_tag')
 

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -183,7 +183,7 @@ class SourceManager(object):
 
     # Was a specific hash specified? Use it as the baseline
     if source_repo.commit_hash and addtional_hashes:
-      hash_set = hash_set.union(source_repo.commit_hash)
+      hash_set = hash_set.union([source_repo.commit_hash])
       return hash_set
 
     # If we don't have a commit_hash specified and no additional hashes

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -20,6 +20,9 @@ def _run_command_side_effect(*args):
 
   Args:
     args: the list of arguments received by the mocked function
+
+  Raises:
+    NotImplementedError: if this method is invoked for an unexpected command
   """
   _verify_cwd(**args[1]._asdict())
 
@@ -64,7 +67,7 @@ v1.15.2
 v1.16.0
 """
 
-  raise Exception(f"Unhandled input in side effect: {args}")
+  raise NotImplementedError(f"Unhandled input in side effect: {args}")
 
 def _generate_default_benchmark_images(job_control):
   """Generate a default image configuration for the job control object.

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -3,11 +3,15 @@ Test source_tree operations needed for executing benchmarks
 """
 from unittest import mock
 import pytest
+import io
 import subprocess
+import tempfile
 
 from src.lib import (cmd_exec, source_tree, constants)
 
 import api.source_pb2 as proto_source
+
+_default_https_repo_url = 'https://github.com/someawesomeproject/repo.git'
 
 def test_is_tag():
   """Verify that we can detect a hash and a git tag."""
@@ -181,14 +185,10 @@ def mock_run_command_side_effect(*function_args):
     raise subprocess.CalledProcessError(1, "msg")
   elif function_args[0] == 'git remote -v':
     return \
-        ("origin  https://www.github.com/_some_random_repo_/repo.git (fetch)\n"
-         "origin  https://www.github.com/_some_random_repo_/repo.git (push)")
+        ("origin  {url} (fetch)\n"
+         "origin  {url} (push)").format(url=_default_https_repo_url)
   elif function_args[0] == \
-      'git clone https://www.github.com/_some_random_repo_/repo.git .':
-    return "Cloning into \'.\'"
-
-  elif function_args[0] == \
-      "git clone https://github.com/_some_random_repo_/repo.git .":
+      'git clone {url} .'.format(url=_default_https_repo_url):
     return "Cloning into \'.\'"
 
   elif function_args[0] == (
@@ -242,7 +242,7 @@ def test_pull(mock_run_command):
   """Verify that we can clone a repository ensuring that the process completed
      without errors.
   """
-  origin = 'https://www.github.com/_some_random_repo_/repo.git'
+  origin = _default_https_repo_url
 
   source = _generate_source_tree_from_origin(origin)
   mock_run_command.side_effect = mock_run_command_side_effect
@@ -251,7 +251,7 @@ def test_pull(mock_run_command):
   assert result
 
   git_status = 'git status'
-  git_clone = 'git clone https://www.github.com/_some_random_repo_/repo.git .'
+  git_clone = 'git clone {url} .'.format(url=_default_https_repo_url)
   cmd_params = cmd_exec.CommandParameters(cwd=mock.ANY)
 
   calls = [
@@ -275,7 +275,7 @@ def test_pull_fail():
 def test_pull_fail_up_to_date(mock_is_up_to_date):
   """Verify that we do not clone a repository that is already up to date."""
 
-  origin = 'https://www.github.com/_some_random_repo_/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   mock_is_up_to_date.return_value = True
@@ -290,7 +290,7 @@ def test_pull_fail_incomplete_operation(mock_is_up_to_date,
   """Verify that we can clone a repository and detect an incomplete
      operation.
   """
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   mock_is_up_to_date.return_value = False
@@ -303,7 +303,7 @@ def test_pull_fail_incomplete_operation(mock_is_up_to_date,
 @mock.patch.object(source_tree.SourceTree, 'pull')
 def test_checkout_commit_hash(mock_pull, mock_run_command):
   """Verify that we can checkout a specified commit hash."""
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   source._source_repo.commit_hash = '012345678abcdef'
@@ -317,7 +317,7 @@ def test_checkout_commit_hash(mock_pull, mock_run_command):
 @mock.patch.object(source_tree.SourceTree, 'pull')
 def test_checkout_commit_hash_fail(mock_pull, mock_run_command):
   """Verify that we can detect a failed git checkout."""
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   source._source_repo.commit_hash = '012345678abcdef'
@@ -334,7 +334,7 @@ def test_get_head_hash(mock_run_command):
   """
 
   mock_run_command.side_effect = mock_run_command_side_effect
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   head_hash = source.get_head_hash()
@@ -345,7 +345,7 @@ def test_get_previous_commit_hash(mock_check_output):
   """
     Verify that we can identify one commit prior to a specified hash.
     """
-  origin = 'https://github.com/_some_random_repo_/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   commit_hash = 'fake_commit_hash_1'
@@ -359,7 +359,7 @@ def test_get_previous_commit_hash_fail(mock_check_output):
   """
     Verify that we can identify one commit prior to a specified hash.
     """
-  origin = 'https://github.com/_some_random_repo_/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   commit_hash = 'fake_commit_hash_1'
@@ -380,7 +380,7 @@ def test_get_previous_commit_fail(mock_check_output):
   """Verify that we can identify a failure when attempting to manage commit
      hashes.
   """
-  origin = 'https://github.com/_some_random_repo_/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   commit_hash = 'invalid_hash_reference'
@@ -397,7 +397,7 @@ def testget_revs_behind_parent_branch():
   """Verify that we can determine how many commits beind the local source tree
      lags behind the remote repository.
   """
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   st = _generate_source_tree_from_origin(origin)
 
   git_cmd = 'git status'
@@ -420,7 +420,7 @@ def testget_revs_behind_parent_branch_up_to_date():
   """Verify that we can determine how many commits beind the local source tree
      lags behind the remote repository.
   """
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   git_cmd = 'git status'
@@ -442,7 +442,7 @@ Changes not staged for commit:
 def test_is_up_to_date():
   """Verify that we can determine a source tree is up to date."""
 
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   with mock.patch(
@@ -460,7 +460,7 @@ v1.15.2
 v1.16.0
 """
 
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   git_cmd = "git tag --list --sort v:refname"
@@ -486,7 +486,7 @@ v1.15.2
 v1.16.0
 """
 
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'
@@ -509,7 +509,7 @@ def test_get_previous_tag_fail():
   hash
   """
 
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'not_a_tag'
@@ -533,7 +533,7 @@ v1.15.1
 v1.15.2
 v1.16.0
 """
-  origin = 'https://github.com/someawesomeproject/repo.git'
+  origin = _default_https_repo_url
   source = _generate_source_tree_from_origin(origin)
 
   current_tag = 'v1.16.0'


### PR DESCRIPTION
In this PR we have another round of miscellaneous fixes and items that were cleaned up.  Most of the changes revolve around string duplication.

Additional changes:
- renamed the job control build target to match the module's filename.  This keeps things a bit more congruent.
- made one bugfix where we created a set union from a string instead of a list containing that single string.
- added the source_manager as a dependency to one of the test modules.
- fixed another instance where `data` needed to be changed to `srcs`.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k, @landesherr