### PR TITLE
[Salvo] Fix dependency spelling error and enforce coverage percentage

### DIFF
--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -21,7 +21,7 @@ fi
 
 
 pip3 install --upgrade --user pip
-pip3 install --upgrade --user setuptool
+pip3 install --upgrade --user setuptools
 pip3 install --user -r requirements.txt
 
 touch ${HOME}/.salvo_deps_installed

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+
+MINIMUM_THRESHOLD=97.0
+
 # This script executes all tests and then evaluates the code coverage
 # for Salvo.  All individual coverage files are merged to provide one
 # report for the entire codebase
@@ -45,3 +48,17 @@ mkdir -p coverage/html
 genhtml coverage/salvo.dat -o coverage/html
 echo "HTML coverage report generated, view by running:"
 echo "  (cd coverage/html && python3 -m http.server)"
+
+# Examine the coverage summary and extract the overall coverage percentage.
+# If the reported threshold drops below the specified threshold, then we
+# fail the build.  There is likely a way to get this from the genhtml output
+# so that we don't have to execute lcov an additional time.  However this works.
+COVERAGE_PERCENTAGE=$(lcov --summary coverage/salvo.dat 2>&1 | grep lines | awk '{print $2}'| tr -d \%)
+
+if (( $(echo "${COVERAGE_PERCENTAGE} < ${MINIMUM_THRESHOLD}" | bc -l) ))
+then
+  echo "Test coverage percentage has dipped below ${MINIMUM_THRESHOLD}%"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This small PR fixes a spelling error in the dependency script.  We also update the coverage script to enforce that the overall coverage percentage does not drop below a minimum threshold.  The threshold is set to 97.0%.  Current coverage is at  98%.

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k, @landesherr