### PR TITLE
Add Binary Benchmark Workflow to Salvo

### DIFF
--- a/salvo/src/lib/benchmark/BUILD
+++ b/salvo/src/lib/benchmark/BUILD
@@ -8,6 +8,7 @@ py_library(
   name = "benchmark",
   srcs = [
       "base_benchmark.py",
+      "binary_benchmark.py",
       "fully_dockerized_benchmark.py",
       "scavenging_benchmark.py"
   ],
@@ -39,10 +40,23 @@ py_test(
   srcs_version = "PY3",
   deps = [
       "//api:schema_proto",
-      "//src/lib:source_manager",
       "//src/lib:generate_test_objects",
       ":benchmark"
   ],
+)
+
+py_test(
+  name = "test_binary_benchmark",
+  srcs = [
+    "test_binary_benchmark.py"
+  ],
+  srcs_version = "PY3",
+  deps = [
+      "//api:schema_proto",
+      "//src/lib/docker_management:docker_image",
+      "//src/lib:generate_test_objects",
+      ":benchmark"
+  ]
 )
 
 py_test(

--- a/salvo/src/lib/benchmark/binary_benchmark.py
+++ b/salvo/src/lib/benchmark/binary_benchmark.py
@@ -100,7 +100,7 @@ class Benchmark(base_benchmark.BaseBenchmark):
       # We don't have the necessary sources or binaries to run Envoy,
       # but we can proceed using Nighthawk's test server as a fallback.
       log.warning("Skipping Envoy preparation - no sources/binaries were provided."
-        "Will proceed with Nighthawk test server.")
+                  "Will proceed with Nighthawk test server.")
       return
     if self.envoy_binary_path:
       if not (os.path.exists(self.envoy_binary_path) \
@@ -108,7 +108,7 @@ class Benchmark(base_benchmark.BaseBenchmark):
         # If an "Envoy" is specified, but is not a valid executable file,
         # try to proceed anyway using Nighthawk's test server.
         log.warning("ENVOY_PATH environment variable specified, but invalid."
-          "Falling back to Nighthawk test server.")
+                    "Falling back to Nighthawk test server.")
         self.use_fallback = True
         return
       # We already have a binary, no need to build
@@ -132,18 +132,18 @@ class Benchmark(base_benchmark.BaseBenchmark):
 
     #todo: refactor args, have frontend specify them via protobuf
     cmd = ("bazel test "
-          "--test_summary=detailed "
-          "--test_output=all "
-          "--test_arg=--log-cli-level=info "
-          "--test_env=ENVOY_IP_TEST_VERSIONS=v4only "
-          "--test_env=HEAPPROFILE= "
-          "--test_env=HEAPCHECK= "
-          "--cache_test_results=no "
-          "--compilation_mode=opt "
-          "--cxxopt=-g "
-          "--cxxopt=-ggdb3 "
-          "--define tcmalloc=gperftools "
-          "//benchmarks:* ")
+           "--test_summary=detailed "
+           "--test_output=all "
+           "--test_arg=--log-cli-level=info "
+           "--test_env=ENVOY_IP_TEST_VERSIONS=v4only "
+           "--test_env=HEAPPROFILE= "
+           "--test_env=HEAPCHECK= "
+           "--cache_test_results=no "
+           "--compilation_mode=opt "
+           "--cxxopt=-g "
+           "--cxxopt=-ggdb3 "
+           "--define tcmalloc=gperftools "
+           "//benchmarks:* ")
 
     cmd_params = cmd_exec.CommandParameters(cwd=self._benchmark_dir)
 

--- a/salvo/src/lib/benchmark/binary_benchmark.py
+++ b/salvo/src/lib/benchmark/binary_benchmark.py
@@ -1,0 +1,174 @@
+"""
+This module contains the methods to perform a Binary benchmark using
+containers for the scripts, nighthawk binaries, and envoy
+
+https://github.com/envoyproxy/nighthawk/blob/master/benchmarks/README.md
+"""
+
+import subprocess
+import logging
+import os
+
+import api.control_pb2 as proto_control
+import api.source_pb2 as proto_source
+
+from src.lib.benchmark import base_benchmark
+from src.lib.builder import (envoy_builder, nighthawk_builder)
+from src.lib import (cmd_exec, source_manager)
+
+log = logging.getLogger(__name__)
+
+
+class BinaryBenchmarkError(Exception):
+  """Error raised when running a binary benchmark in cases
+     where we cannot make progress due to abnormal conditions.
+  """
+
+class Benchmark(base_benchmark.BaseBenchmark):
+  """This benchmark class is the binary benchmark. We use a path to an Envoy
+     binary to execute the Nighthawk benchmarks using that specific build.
+  """
+
+  def __init__(
+    self, job_control: proto_control.JobControl, benchmark_name: str) -> None:
+    """ Initialize the benchmark class."""
+
+    super(Benchmark, self).__init__(job_control, benchmark_name)
+    self._benchmark_dir = None
+    self.envoy_binary_path = job_control.environment.variables['ENVOY_PATH']
+    self.envoy_builder = None
+    self.nighthawk_builder = None
+    self.source_manager = source_manager.SourceManager(job_control)
+    self.use_fallback = False
+
+  def _validate(self) -> None:
+    """Validate that all data required for running a benchmark exists.
+
+    Verify that a source has been specified with which to build Nighthawk,
+    warns the user if no valid Envoy binary is specified.
+
+    Returns:
+        None
+    """
+
+    source = self.get_source()
+    if not source:
+      raise BinaryBenchmarkError("No source configuration specified")
+
+    can_build_envoy = False
+    can_build_nighthawk = False
+
+    for source_def in source:
+      if source_def.identity == source_def.SRCID_UNSPECIFIED:
+        raise BinaryBenchmarkError("No source identity specified")
+
+      if source_def.identity == source_def.SRCID_ENVOY and \
+        (source_def.source_path or source_def.source_url):
+        can_build_envoy = True
+
+      if source_def.identity == source_def.SRCID_NIGHTHAWK and \
+        (source_def.source_path or source_def.source_url):
+        can_build_nighthawk = True
+
+    if not can_build_nighthawk:
+      raise BinaryBenchmarkError("No source specified to build Nighthawk")
+
+    if not (can_build_envoy or self.envoy_binary_path):
+      self.use_fallback = True
+      log.warning("No Envoy source or binary was specified. Falling back to Nighthawk test server.")
+
+
+  def _prepare_nighthawk(self) -> None:
+    """Prepare the nighthawk source for the benchmark.
+
+    Checks out the nighthawk source if necessary, builds the client
+    and server binaries
+
+    """
+
+    self.nighthawk_builder = nighthawk_builder.NightHawkBuilder(self.source_manager)
+    self.nighthawk_builder.build_nighthawk_binaries()
+    self.nighthawk_builder.build_nighthawk_benchmarks()
+
+    nighthawk_source = self.source_manager.get_source_tree(
+        proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK
+    )
+    self._benchmark_dir = nighthawk_source.get_source_directory()
+
+  def _prepare_envoy(self) -> None:
+    if self.use_fallback:
+      # We don't have the necessary sources or binaries to run Envoy,
+      # but we can proceed using Nighthawk's test server as a fallback.
+      log.warning("Skipping Envoy preparation - no sources/binaries were provided."
+        "Will proceed with Nighthawk test server.")
+      return
+    if self.envoy_binary_path:
+      if not (os.path.exists(self.envoy_binary_path) \
+          and os.access(self.envoy_binary_path, os.X_OK)):
+        # If an "Envoy" is specified, but is not a valid executable file,
+        # try to proceed anyway using Nighthawk's test server.
+        log.warning("ENVOY_PATH environment variable specified, but invalid."
+          "Falling back to Nighthawk test server.")
+        self.use_fallback = True
+        return
+      # We already have a binary, no need to build
+      log.info("Using Envoy binary specified in ENVOY_PATH environment variable")
+      return
+
+    self.envoy_builder = envoy_builder.EnvoyBuilder(self.source_manager)
+    self.envoy_binary_path = self.envoy_builder.build_envoy_binary_from_source()
+
+
+  def execute_benchmark(self) -> None:
+    """Execute the binary benchmark
+
+    Uses either the Envoy specified in ENVOY_PATH, or one built from a
+    specified source.
+    """
+
+    self._validate()
+    self._prepare_nighthawk()
+    self._prepare_envoy()
+
+    #todo: refactor args, have frontend specify them via protobuf
+    cmd = ("bazel test "
+          "--test_summary=detailed "
+          "--test_output=all "
+          "--test_arg=--log-cli-level=info "
+          "--test_env=ENVOY_IP_TEST_VERSIONS=v4only "
+          "--test_env=HEAPPROFILE= "
+          "--test_env=HEAPCHECK= "
+          "--cache_test_results=no "
+          "--compilation_mode=opt "
+          "--cxxopt=-g "
+          "--cxxopt=-ggdb3 "
+          "--define tcmalloc=gperftools "
+          "//benchmarks:* ")
+
+    cmd_params = cmd_exec.CommandParameters(cwd=self._benchmark_dir)
+
+    # pull in environment and set values
+    env = self._control.environment
+
+    # 'TMPDIR' is required for successful operation.  This is the output
+    # directory for all produced NightHawk artifacts
+    binary_benchmark_vars = {
+      'TMPDIR': env.output_dir
+    }
+    if self.envoy_binary_path:
+      binary_benchmark_vars['ENVOY_PATH'] = self.envoy_binary_path
+
+    log.debug(f"Using environment: {binary_benchmark_vars}")
+
+    for (key, value) in binary_benchmark_vars.items():
+      if key not in env.variables:
+        log.debug(f"Building control environment variables: {key}={value}")
+        env.variables[key] = value
+
+    environment_controller = base_benchmark.BenchmarkEnvController(env)
+
+    with environment_controller:
+      try:
+        cmd_exec.run_command(cmd, cmd_params)
+      except subprocess.CalledProcessError as cpe:
+        log.error(f"Unable to execute the benchmark: {cpe}")

--- a/salvo/src/lib/benchmark/binary_benchmark.py
+++ b/salvo/src/lib/benchmark/binary_benchmark.py
@@ -37,9 +37,6 @@ class Benchmark(base_benchmark.BaseBenchmark):
         job_control: The protobuf object containing the parameters and locations
           of benchmark artifacts
         benchmark_name: The name of the benchmark to execute
-
-    Raises:
-        BaseBenchmarkError: if no job control object is specified
     """
 
     super(Benchmark, self).__init__(job_control, benchmark_name)

--- a/salvo/src/lib/benchmark/test_binary_benchmark.py
+++ b/salvo/src/lib/benchmark/test_binary_benchmark.py
@@ -11,6 +11,16 @@ import api.control_pb2 as proto_control
 from src.lib.benchmark import binary_benchmark
 from src.lib import generate_test_objects
 
+_BUILD_NIGHTHAWK_BENCHMARKS = \
+    ('src.lib.builder.nighthawk_builder.NightHawkBuilder'
+     '.build_nighthawk_benchmarks')
+_BUILD_NIGHTHAWK_BINARIES = \
+    ('src.lib.builder.nighthawk_builder.NightHawkBuilder'
+     '.build_nighthawk_binaries')
+_BUILD_ENVOY_BINARY = \
+    ('src.lib.builder.envoy_builder.EnvoyBuilder'
+     '.build_envoy_binary_from_source')
+
 def test_no_sources():
   """Test benchmark validation logic.
 
@@ -32,9 +42,9 @@ def test_no_sources():
   assert str(validation_error.value) == "No source configuration specified"
 
 # Mock the build invocations so we don't actually try to build this big chungus
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
-@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch(_BUILD_NIGHTHAWK_BENCHMARKS)
+@patch(_BUILD_NIGHTHAWK_BINARIES)
+@patch(_BUILD_ENVOY_BINARY)
 @patch('src.lib.cmd_exec.run_command')
 def test_source_to_build_binaries(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
   """Validate we can build binaries from source.
@@ -88,9 +98,9 @@ def test_no_source_to_build_nh():
       "No source specified to build Nighthawk"
 
 # Mock the build invocations so we don't actually try to build this big chungus
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
-@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch(_BUILD_NIGHTHAWK_BENCHMARKS)
+@patch(_BUILD_NIGHTHAWK_BINARIES)
+@patch(_BUILD_ENVOY_BINARY)
 @patch('src.lib.cmd_exec.run_command')
 def test_fallback_envoy(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
   """Validate that we proceed when Envoy sources are not present
@@ -116,9 +126,9 @@ def test_fallback_envoy(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_b
   mock_nh_bench_build.assert_called_once()
   mock_nh_bin_build.assert_called_once()
 
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
-@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch(_BUILD_NIGHTHAWK_BENCHMARKS)
+@patch(_BUILD_NIGHTHAWK_BINARIES)
+@patch(_BUILD_ENVOY_BINARY)
 @patch('src.lib.cmd_exec.run_command')
 def test_envoy_build_failure(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
   """Validate that an exception is raised which halts the benchmark execution
@@ -145,9 +155,9 @@ def test_envoy_build_failure(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock
   mock_nh_bench_build.assert_called_once()
   mock_nh_bin_build.assert_called_once()
 
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
-@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
-@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch(_BUILD_NIGHTHAWK_BENCHMARKS)
+@patch(_BUILD_NIGHTHAWK_BINARIES)
+@patch(_BUILD_ENVOY_BINARY)
 @patch('src.lib.cmd_exec.run_command')
 def test_nh_build_failure(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
   """Validate that an exception is raised which halts the benchmark execution

--- a/salvo/src/lib/benchmark/test_binary_benchmark.py
+++ b/salvo/src/lib/benchmark/test_binary_benchmark.py
@@ -1,0 +1,183 @@
+"""
+Test the fully dockerized benchmark class
+"""
+
+import pytest
+import subprocess
+from unittest.mock import patch
+
+import api.control_pb2 as proto_control
+
+from src.lib.benchmark import binary_benchmark
+from src.lib import generate_test_objects
+
+def test_no_sources():
+  """Test benchmark validation logic.
+
+  We expect the validation logic to throw an exception,
+  since no sources are present
+  """
+  # create a valid configuration with no images
+  job_control = generate_test_objects.generate_default_job_control()
+
+  generate_test_objects.generate_environment(job_control)
+
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark should throw an exception
+  with pytest.raises(binary_benchmark.BinaryBenchmarkError) \
+      as validation_error:
+    benchmark.execute_benchmark()
+
+  assert str(validation_error.value) == "No source configuration specified"
+
+# Mock the build invocations so we don't actually try to build this big chungus
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
+@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch('src.lib.cmd_exec.run_command')
+def test_source_to_build_binaries(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
+  """Validate we can build binaries from source.
+
+  Validate that sources are defined that enable us to build Envoy/Nighthawk
+  We do not expect the validation logic to throw an exception
+  """
+  # create a valid configuration with a missing Envoy image
+  job_control = generate_test_objects.generate_default_job_control()
+
+  generate_test_objects.generate_envoy_source(job_control)
+  generate_test_objects.generate_nighthawk_source(job_control)
+  generate_test_objects.generate_environment(job_control)
+
+  # Setup mock values
+  mock_envoy_path = "/home/ubuntu/envoy/bazel-bin/source/exe/envoy-static"
+  mock_envoy_build.return_value = mock_envoy_path
+
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+
+  benchmark.execute_benchmark()
+  assert benchmark.envoy_binary_path == mock_envoy_path
+  mock_envoy_build.assert_called_once()
+  mock_nh_bench_build.assert_called_once()
+  mock_nh_bin_build.assert_called_once()
+
+def test_no_source_to_build_nh():
+  """Validate that we fail the entire process in the absence of NH sources
+
+  Validate that even if Envoy sources are specified, the absence of Nighthawk
+  sources will cause the program to fail.
+
+  We expect the validation logic to throw an exception
+  """
+  # create a valid configuration with a missing NightHawk container image
+  job_control = proto_control.JobControl(
+      remote=False,
+      binary_benchmark=True
+  )
+
+  generate_test_objects.generate_envoy_source(job_control)
+  generate_test_objects.generate_environment(job_control)
+
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+
+  # Calling execute_benchmark should throw an exception
+  with pytest.raises(Exception) as validation_exception:
+    benchmark.execute_benchmark()
+
+  assert str(validation_exception.value) == \
+      "No source specified to build Nighthawk"
+
+# Mock the build invocations so we don't actually try to build this big chungus
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
+@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch('src.lib.cmd_exec.run_command')
+def test_fallback_envoy(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
+  """Validate that we proceed when Envoy sources are not present
+
+  Validate that a fallback to the Nighthawk test server is triggered
+  when no Envoy sources or binaries are specified.
+
+  We do not expect the validation logic to throw an exception
+  """
+  # create a valid configuration with a missing both NightHawk container images
+  job_control = proto_control.JobControl(
+      remote=False,
+      binary_benchmark=True
+  )
+
+  generate_test_objects.generate_nighthawk_source(job_control)
+  generate_test_objects.generate_environment(job_control)
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+
+  benchmark.execute_benchmark()
+  assert benchmark.use_fallback
+  mock_envoy_build.assert_not_called()
+  mock_nh_bench_build.assert_called_once()
+  mock_nh_bin_build.assert_called_once()
+
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
+@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch('src.lib.cmd_exec.run_command')
+def test_envoy_build_failure(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
+  """Validate that an exception is raised which halts the benchmark execution
+  when the Envoy build fails
+
+  We expect an unhandled exception to surface from _prepare_envoy
+  """
+  # Setup mock values
+  mock_envoy_build.side_effect = subprocess.CalledProcessError(1, "foo")
+
+  job_control = generate_test_objects.generate_default_job_control()
+
+  generate_test_objects.generate_envoy_source(job_control)
+  generate_test_objects.generate_nighthawk_source(job_control)
+  generate_test_objects.generate_environment(job_control)
+
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+  with pytest.raises(Exception) as build_exception:
+    benchmark.execute_benchmark()
+
+  assert str(build_exception.value) == "Command 'foo' returned non-zero exit status 1."
+  assert not benchmark.envoy_binary_path
+  # We expect the nighthawk build to occur before the Envoy build fails
+  mock_nh_bench_build.assert_called_once()
+  mock_nh_bin_build.assert_called_once()
+
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_benchmarks')
+@patch('src.lib.builder.nighthawk_builder.NightHawkBuilder.build_nighthawk_binaries')
+@patch('src.lib.builder.envoy_builder.EnvoyBuilder.build_envoy_binary_from_source')
+@patch('src.lib.cmd_exec.run_command')
+def test_nh_build_failure(mock_cmd, mock_envoy_build, mock_nh_bin_build, mock_nh_bench_build):
+  """Validate that an exception is raised which halts the benchmark execution
+  when the Nighthawk build fails
+
+  We expect an unhandled exception to surface from _prepare_nighthawk
+  """
+  # Setup mock values
+  mock_nh_bench_build.side_effect = subprocess.CalledProcessError(1, "bar")
+  mock_envoy_path = "/home/ubuntu/envoy/bazel-bin/source/exe/envoy-static"
+  mock_envoy_build.return_value = mock_envoy_path
+
+  job_control = generate_test_objects.generate_default_job_control()
+
+  generate_test_objects.generate_envoy_source(job_control)
+  generate_test_objects.generate_nighthawk_source(job_control)
+  generate_test_objects.generate_environment(job_control)
+
+  benchmark = binary_benchmark.Benchmark(job_control, "test_benchmark")
+  with pytest.raises(Exception) as build_exception:
+    benchmark.execute_benchmark()
+
+  assert str(build_exception.value) == "Command 'bar' returned non-zero exit status 1."
+  assert not benchmark.envoy_binary_path
+  # We expect the nighthawk binary build to occur
+  # before the benchmark build fails
+  mock_nh_bin_build.assert_called_once()
+  # Raising an exception during the nighthawk build should prevent control flow
+  # from proceeding to build Envoy
+  mock_envoy_build.assert_not_called()
+
+if __name__ == '__main__':
+  raise SystemExit(pytest.main(['-s', '-v', __file__]))

--- a/salvo/src/lib/builder/envoy_builder.py
+++ b/salvo/src/lib/builder/envoy_builder.py
@@ -66,21 +66,36 @@ class EnvoyBuilder(base_builder.BaseBuilder):
     cmd += constants.ENVOY_BINARY_BUILD_TARGET
     cmd_exec.run_check_command(cmd, cmd_params)
 
-  def build_envoy_image_from_source(self) -> None:
-    """Build an Envoy docker image from source.
+  def build_envoy_binary_from_source(self) -> str:
+    """Build an Envoy binary from source.
 
-    This method performs all the steps necessary to generate an Envoy docker
-    image
+    This method cleans the working directory, compiles the binary,
+    and returns the name of the final envoy binary.
 
     Returns:
-      None
+      A string representation of the path to the created binary
     """
 
     self._validate()
     self._source_tree.copy_source_directory()
     self._source_tree.checkout_commit_hash()
+
     self.clean_envoy()
     self.build_envoy()
+
+    return os.path.join(self._build_dir, constants.ENVOY_BINARY_TARGET_OUTPUT_PATH)
+
+  def build_envoy_image_from_source(self) -> None:
+    """Build an Envoy docker image from source.
+
+    This method performs a few steps. It compiles the envoy binary,
+    stages it for inclusion in a docker image, and builds the docker
+    image.
+
+    Returns:
+      None
+    """
+    self.build_envoy_binary_from_source()
     self.stage_envoy(False)
     self.create_docker_image()
 

--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -44,6 +44,26 @@ def _check_call_side_effect(args, parameters):
 @mock.patch('src.lib.cmd_exec.run_command')
 @mock.patch.object(source_tree.SourceTree, 'checkout_commit_hash')
 @mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
+def test_build_envoy_binary_from_source(mock_copy_source,
+                                       mock_checkout_hash,
+                                       mock_run_command,
+                                       mock_run_check_command):
+  """Verify the calls made to build an envoy binary from source."""
+  mock_copy_source.return_value = None
+  mock_checkout_hash.return_value = None
+  mock_run_command.side_effect = _check_call_side_effect
+  mock_run_check_command.side_effect = _check_call_side_effect
+
+  manager = _generate_default_source_manager()
+  builder = envoy_builder.EnvoyBuilder(manager)
+  binary_path = builder.build_envoy_binary_from_source()
+
+  assert constants.ENVOY_BINARY_TARGET_OUTPUT_PATH in binary_path
+
+@mock.patch('src.lib.cmd_exec.run_check_command')
+@mock.patch('src.lib.cmd_exec.run_command')
+@mock.patch.object(source_tree.SourceTree, 'checkout_commit_hash')
+@mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
 def test_build_envoy_image_from_source(mock_copy_source,
                                        mock_checkout_hash,
                                        mock_run_command,

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -167,10 +167,11 @@ class BenchmarkRunner(object):
        Args:
         images: the DockerImages appearing in the control object
     """
-    di = docker_image.DockerImage()
+
     pull_result = False
     try:
-      pull_result = di.pull_image(images.nighthawk_benchmark_image)
+      image_manager = docker_image.DockerImage()
+      pull_result = image_manager.pull_image(images.nighthawk_benchmark_image)
     except docker_image.DockerImagePullError:
       log.error(f"Image pull failed for {images.nighthawk_benchmark_image}")
 

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -18,29 +18,6 @@ import api.image_pb2 as proto_image
 
 log = logging.getLogger(__name__)
 
-def create_symlink_for_test_artifacts(output_dir: str,
-                                      image_tag: str) -> None:
-  """Create a symlink linking the artifacts for easy identification.
-
-  Creates a symlink named with the value of 'image_tag' which points to the
-  output directory containing the artifacts for the image beign tested.  The
-  target of the link is the tag or commit hash from which the docker image
-  was created.  This is analogous to the set of bazel-* directories created
-  in a build.
-
-  Args:
-    output_dir: The location on disk where output artifacts are placed
-    image_tag: The tag or commit hash for the image used for the symlink name
-
-  Returns:
-    None
-  """
-
-  if os.path.islink(image_tag) and output_dir == os.readlink(image_tag):
-    return
-
-  # Create a symbolic link pointing to 'output_dir' named 'image_tag'.
-  os.symlink(output_dir, image_tag)
 
 class BenchmarkRunnerError(Exception):
   """An error raised if if an unrecoverable condition arises when executing
@@ -85,7 +62,7 @@ class BenchmarkRunner(object):
 
     if self._control.scavenging_benchmark:
       current_benchmark_name = "Scavenging Benchmark"
-      job_control_list = self.generate_job_control_for_envoy_images()
+      job_control_list = self._generate_job_control_for_envoy_images()
 
       for job_control in job_control_list:
         benchmark = scavenging.Benchmark(job_control, current_benchmark_name)
@@ -93,7 +70,7 @@ class BenchmarkRunner(object):
 
     elif self._control.dockerized_benchmark:
       current_benchmark_name = "Fully Dockerized Benchmark"
-      job_control_list = self.generate_job_control_for_envoy_images()
+      job_control_list = self._generate_job_control_for_envoy_images()
 
       for job_control in job_control_list:
         benchmark = fulldocker.Benchmark(job_control, current_benchmark_name)
@@ -102,25 +79,21 @@ class BenchmarkRunner(object):
     elif self._control.binary_benchmark:
       current_benchmark_name = "Binary Benchmark"
       # Not working with docker images here, so use custom binary-oriented job control generation
-      job_control_list = self.generate_job_control_for_binaries()
+      job_control_list = self._generate_job_control_for_binaries()
 
       for job_control in job_control_list:
         benchmark = binbench.Benchmark(job_control, current_benchmark_name)
         self._test.append(benchmark)
 
     if not self._test:
-      raise NotImplementedError(f"No [{current_benchmark_name}] defined yet")
+      raise NotImplementedError(f"No [{current_benchmark_name}] defined")
 
-  def generate_job_control_for_envoy_images(self) \
+  def _generate_job_control_for_envoy_images(self) \
       -> List[proto_control.JobControl]:
     """Determine the required envoy images needed for the benchmark.
 
     Find the commit hashes or tags for all envoy images, build images if
     necessary.
-
-    Raises:
-      RuntimeError: if we are unable to build or pull an Envoy image
-        for testing.
     """
 
     # Get the images that we are benchmarking. Source Manager will
@@ -129,16 +102,16 @@ class BenchmarkRunner(object):
 
     envoy_images = self._pull_or_build_envoy_images_for_benchmark(image_hashes)
     if not envoy_images:
-      raise RuntimeError("Unable to find or build images for benchmark")
+      raise Exception("Unable to find or build images for benchmark")
 
     self._pull_or_build_nighthawk_images_for_benchmark()
 
     log.debug(f"Using {envoy_images} for benchmark")
-    job_control_list = self.create_job_control_for_images(envoy_images)
+    job_control_list = self._create_job_control_for_images(envoy_images)
 
     return job_control_list
 
-  def generate_job_control_for_binaries(self) \
+  def _generate_job_control_for_binaries(self) \
     -> List[proto_control.JobControl]:
     """Determine the required source configurations needed for a binary benchmark.
 
@@ -146,7 +119,7 @@ class BenchmarkRunner(object):
     commits to be tested. These will be spawned into multiple Binary Benchmark jobs.
 
     Raises:
-      RuntimeError: when multiple competing repositories of Envoy/Nighthawk are specified.
+      Exception: when multiple competing repositories of Envoy/Nighthawk are specified.
     """
 
     # Find the specified version of Nighthawk and use it for all job controls
@@ -155,11 +128,11 @@ class BenchmarkRunner(object):
     for source_item in self._control.source:
       if source_item.identity == proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
         if nighthawk_source:
-          raise RuntimeError("Multiple Nighthawk sources specified. Please specify only one.")
+          raise Exception("Multiple Nighthawk sources specified. Please specify only one.")
         nighthawk_source = source_item
 
     if not nighthawk_source:
-      raise RuntimeError("No Nighthawk sources specified")
+      raise Exception("No Nighthawk sources specified")
 
     log.info("Using Nighthawk sources at " \
       + getattr(nighthawk_source, nighthawk_source.WhichOneof('source_location')))
@@ -168,11 +141,11 @@ class BenchmarkRunner(object):
     for source_item in self._control.source:
       if source_item.identity == proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:
         if envoy_source:
-          raise RuntimeError("Multiple Envoy sources specified. Please specify only one.")
+          raise Exception("Multiple Envoy sources specified. Please specify only one.")
         envoy_source = source_item
 
     if not envoy_source:
-      raise RuntimeError("No Envoy sources specified")
+      raise Exception("No Envoy sources specified")
 
     envoy_hashes = [envoy_source.commit_hash]
     for envoy_hash in envoy_source.additional_hashes:
@@ -215,10 +188,11 @@ class BenchmarkRunner(object):
       Args:
         images: the DockerImages appearing in the control object
     """
-    di = docker_image.DockerImage()
+
     pull_result = False
     try:
-      pull_result = di.pull_image(images.nighthawk_binary_image)
+      image_manager = docker_image.DockerImage()
+      pull_result = image_manager.pull_image(images.nighthawk_binary_image)
     except docker_image.DockerImagePullError:
       log.error(f"Image pull failed for {images.nighthawk_binary_image}")
 
@@ -267,19 +241,18 @@ class BenchmarkRunner(object):
         proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY)
 
     envoy_images = set()
-    di = docker_image.DockerImage()
+    image_manager = docker_image.DockerImage()
 
     log.debug(f"Finding matching images for hashes: {image_hashes}")
 
     for image_hash in image_hashes:
-      assert image_hash
       image_prefix = docker_image_builder.get_envoy_image_prefix(image_hash)
       envoy_image = "{prefix}:{hash}".format(prefix=image_prefix,
                                              hash=image_hash)
 
       image_object = None
       try:
-        image_object = di.pull_image(envoy_image)
+        image_object = image_manager.pull_image(envoy_image)
       except docker_image.DockerImagePullError:
         log.error(f"Image pull failed for {envoy_image}")
 
@@ -315,7 +288,7 @@ class BenchmarkRunner(object):
     new_job_control.images.envoy_image = envoy_image
     new_job_control.environment.output_dir = output_dir
 
-    create_symlink_for_test_artifacts(output_dir, image_hash)
+    self._create_symlink_for_test_artifacts(output_dir, image_hash)
 
     return new_job_control
 
@@ -359,11 +332,11 @@ class BenchmarkRunner(object):
     log.debug(f"Creating new Binary job for {new_envoy_source}")
     log.debug(f"Job:\n{new_job_control}")
 
-    create_symlink_for_test_artifacts(output_dir, identifier)
+    self._create_symlink_for_test_artifacts(output_dir, identifier)
 
     return new_job_control
 
-  def create_job_control_for_images(
+  def _create_job_control_for_images(
       self, envoy_images: Set[str]) -> List[proto_control.JobControl]:
     """Create new job control objects for each benchmark
 
@@ -394,6 +367,30 @@ class BenchmarkRunner(object):
 
     return job_control_list
 
+  def _create_symlink_for_test_artifacts(self, output_dir: str,
+                                         image_tag: str) -> None:
+    """Create a symlink linking the artifacts for easy identification.
+
+    Creates a symlink named with the value of 'image_tag' which points to the
+    output directory containing the artifacts for the image beign tested.  The
+    target of the link is the tag or commit hash from which the docker image
+    was created.  This is analogous to the set of bazel-* directories created
+    in a build.
+
+    Args:
+      output_dir: The location on disk where output artifacts are placed
+      image_tag: The tag or commit hash for the image used for the symlink name
+
+    Returns:
+      None
+    """
+
+    if os.path.islink(image_tag) and output_dir == os.readlink(image_tag):
+      return
+
+    # Create a symbolic link pointing to 'output_dir' named 'image_tag'.
+    os.symlink(output_dir, image_tag)
+
   def execute(self) -> None:
     """Run the instantiated benchmark.
 
@@ -403,7 +400,16 @@ class BenchmarkRunner(object):
 
     The benchmarks are run sequentially so that they do not interfere with each
     other.
+
+    Raises:
+      NotImplementedError: we have not implemented remote benchmarks yet.  This
+        exception alerts us to another point in the execution path that may need
+        to be modified
     """
+    if self._control.remote:
+      # Kick things off in parallel
+      raise NotImplementedError(
+          "Remote benchmarks have not been implemented yet")
 
     bar = '=' * 20
     for benchmark in self._test:

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -7,8 +7,11 @@ import logging
 import os
 from typing import (List, Set)
 
-from src.lib.benchmark import (fully_dockerized_benchmark as fulldocker,
-  scavenging_benchmark as scavenging, binary_benchmark as binbench, base_benchmark)
+from src.lib.benchmark import fully_dockerized_benchmark as fulldocker
+from src.lib.benchmark import scavenging_benchmark as scavenging
+from src.lib.benchmark import binary_benchmark as binbench
+from src.lib.benchmark import base_benchmark
+
 from src.lib.docker_management import (docker_image, docker_image_builder)
 from src.lib import source_manager
 
@@ -119,7 +122,7 @@ class BenchmarkRunner(object):
     commits to be tested. These will be spawned into multiple Binary Benchmark jobs.
 
     Raises:
-      Exception: when multiple competing repositories of Envoy/Nighthawk are specified.
+      BenchmarkRunnerError: when multiple competing repositories of Envoy/Nighthawk are specified.
     """
 
     # Find the specified version of Nighthawk and use it for all job controls
@@ -128,11 +131,12 @@ class BenchmarkRunner(object):
     for source_item in self._control.source:
       if source_item.identity == proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:
         if nighthawk_source:
-          raise Exception("Multiple Nighthawk sources specified. Please specify only one.")
+          raise BenchmarkRunnerError("Multiple Nighthawk sources specified."
+                                     "Please specify only one.")
         nighthawk_source = source_item
 
     if not nighthawk_source:
-      raise Exception("No Nighthawk sources specified")
+      raise BenchmarkRunnerError("No Nighthawk sources specified")
 
     log.info("Using Nighthawk sources at " \
       + getattr(nighthawk_source, nighthawk_source.WhichOneof('source_location')))
@@ -141,11 +145,12 @@ class BenchmarkRunner(object):
     for source_item in self._control.source:
       if source_item.identity == proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:
         if envoy_source:
-          raise Exception("Multiple Envoy sources specified. Please specify only one.")
+          raise BenchmarkRunnerError("Multiple Envoy sources specified."
+                                     "Please specify only one.")
         envoy_source = source_item
 
     if not envoy_source:
-      raise Exception("No Envoy sources specified")
+      raise BenchmarkRunnerError("No Envoy sources specified")
 
     envoy_hashes = [envoy_source.commit_hash]
     for envoy_hash in envoy_source.additional_hashes:

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -9,7 +9,7 @@ from typing import (List, Set)
 
 from src.lib.benchmark import fully_dockerized_benchmark as fulldocker
 from src.lib.benchmark import scavenging_benchmark as scavenging
-from src.lib.benchmark import binary_benchmark as binbench
+from src.lib.benchmark import binary_benchmark
 from src.lib.benchmark import base_benchmark
 
 from src.lib.docker_management import (docker_image, docker_image_builder)
@@ -85,7 +85,7 @@ class BenchmarkRunner(object):
       job_control_list = self._generate_job_control_for_binaries()
 
       for job_control in job_control_list:
-        benchmark = binbench.Benchmark(job_control, current_benchmark_name)
+        benchmark = binary_benchmark.Benchmark(job_control, current_benchmark_name)
         self._test.append(benchmark)
 
     if not self._test:

--- a/salvo/src/lib/test_run_benchmark.py
+++ b/salvo/src/lib/test_run_benchmark.py
@@ -167,7 +167,7 @@ def test_benchmark_failure_if_no_benchmark_selected():
     _ = run_benchmark.BenchmarkRunner(job_control)
 
   assert str(not_implemented.value) == \
-      "No [Unspecified Benchmark] defined yet"
+      "No [Unspecified Benchmark] defined"
 
 if __name__ == '__main__':
   raise SystemExit(pytest.main(['-s', '-v', __file__]))


### PR DESCRIPTION
This PR adds the 3rd and final benchmark style, the BinaryBenchmark,
which builds Envoy and Nighthawk from source, and tests the native
binaries, rather than docker images.

Signed-off-by: Nolan Varani <landesherr@users.noreply.github.com>

cc: @mum4k @abaptiste 