### PR TITLE
[Salvo] Binary benchmark updates

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -6,6 +6,7 @@ This is a framework that abstracts executing multiple benchmarks of the Envoy Pr
 
 The control document defines the data needed to execute a benchmark. At the moment, we support the fully dockerized benchmark and the scavenging benchmark.  The work for the binary benchmark is in progress.
 
+### Fully Dockerized Benchmark
 The Fully Dockerized Benchmark discoveres user supplied tests for execution and uses docker images to run the tests. In the example below, the user supplied tests files are located in `/home/ubuntu/nighthawk_tests` and are mapped to a volume in the docker container.
 
 To run the dockerized benchmark, create a file with the following example contents:
@@ -50,6 +51,7 @@ images:
 
 In both examples above, the envoy image being tested is a specific tag. This tag can be replaced with "latest" to test the most recently created image against the previous image built from the prior tag. If a commit hash is used, we find the previous commit hash and benchmark that container.  In summary, tags are compared to tags, hashes are compared to hashes.
 
+### Scavenging Benchmark
 The 'Scavenging' Benchmark runs the benchmark on the local machine and uses a specified Envoy image for testing.  Tests are discovered in the specified directory in the Environment object:
 
 ```yaml
@@ -77,6 +79,30 @@ source:
 ```
 
 In this example, the v1.16.0 Envoy tag is pulled and an Envoy image generated where the Envoy binary has profiling enabled.  The user may specify option strings supported by bazel to adjust the compilation process.
+
+### Binary Benchmark
+The binary benchmark runs an envoy binary as the test target.  The binary is compiled from the source commit specified.  As is the case with other benchmarks as well, the previous commit is deduced and a benchmark is executed for these code points. All NightHawk components are built from source.  This benchmark runs on the local host directly.
+
+Example Job Control specification for executing a binary benchmark:
+
+```yaml
+remote: false
+binaryBenchmark: true
+environment:
+  outputDir: /home/ubuntu/nighthawk_output
+  testDir: /home/ubuntu/nighthawk_tests
+  testVersion: IPV_V4ONLY
+images:
+  nighthawkBenchmarkImage: envoyproxy/nighthawk-benchmark-dev:latest
+  nighthawkBinaryImage: envoyproxy/nighthawk-dev:latest
+source:
+- identity: SRCID_ENVOY
+  commit_hash: v1.16.0
+  source_url: https://github.com/envoyproxy/envoy.git
+- identity: SRCID_NIGHTHAWK
+  source_url: https://github.com/envoyproxy/nighthawk.git
+```
+
 
 ## Building Salvo
 

--- a/salvo/src/lib/benchmark/binary_benchmark.py
+++ b/salvo/src/lib/benchmark/binary_benchmark.py
@@ -46,6 +46,22 @@ class Benchmark(base_benchmark.BaseBenchmark):
     self._nighthawk_builder = None
     self._source_manager = source_manager.SourceManager(job_control)
 
+  def get_image(self) -> str:
+    """Return the commit hash string for the Envoy version being tested.
+
+    Since the binary benchmark does not use images, we supply the branch.
+    This string is used in the output log banner indicating the current
+    object version being tested.
+
+    Return:
+      a string containing the commit hash matching the binary under test
+    """
+
+    envoy_source = self._source_manager.get_source_repository(
+        proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY
+    )
+    return envoy_source.commit_hash if envoy_source.commit_hash else "Unset"
+
   def _validate(self) -> None:
     """Validate that all data required for running a benchmark exists.
 

--- a/salvo/src/lib/builder/envoy_builder.py
+++ b/salvo/src/lib/builder/envoy_builder.py
@@ -63,6 +63,14 @@ class EnvoyBuilder(base_builder.BaseBuilder):
     )
     if not cmd.endswith(" "):
       cmd += " "
+
+    # Encountered this message building on Ubuntu 20.04
+    # 'user_link_flags' is deprecated and will be removed soon.
+    # It may be temporarily re-enabled by setting
+    # --incompatible_require_linker_input_cc_api=false
+    if os.getenv('SALVO_WORKAROUND_LINK_ERROR'):
+      cmd += "--incompatible_require_linker_input_cc_api=false "
+
     cmd += constants.ENVOY_BINARY_BUILD_TARGET
     cmd_exec.run_check_command(cmd, cmd_params)
 

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -128,8 +128,14 @@ class SourceManager(object):
     if not all([
         images.nighthawk_benchmark_image, images.nighthawk_binary_image
     ]):
-      raise SourceManagerError(
-          "No images are specified in the control document")
+        # Determine whether we have sources for building NightHawk
+        nighthawk_source = self.get_source_tree(
+            proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK
+        )
+        if not nighthawk_source:
+          raise SourceManagerError(
+              "No images are specified or able to be built from the "
+              "control document")
 
     envoy_image = images.envoy_image
     if not envoy_image:

--- a/salvo/src/lib/test_run_benchmark.py
+++ b/salvo/src/lib/test_run_benchmark.py
@@ -23,20 +23,22 @@ _BUILD_NIGHTHAWK_BENCHMARK_IMAGE_FROM_SOURCE = \
      '.build_nighthawk_benchmark_image_from_source')
 
 @mock.patch('os.symlink')
-@mock.patch.object(source_manager.SourceManager, 'have_build_options')
-def test_binary_benchmark_setup(
-    mock_have_build_options,
-    mock_symlink):
+@mock.patch.object(source_manager.SourceManager, 'get_envoy_hashes_for_benchmark')
+def test_binary_benchmark_setup(mock_get_hashes, mock_symlink):
   """Verify that the unique methods to the binary benchmark workflow are in order"""
   job_control = proto_control.JobControl(
       remote=False,
       binary_benchmark=True
   )
+  mock_get_hashes.return_value = [ "jedi", "padawan" ]
   generate_test_objects.generate_envoy_source(job_control)
   generate_test_objects.generate_nighthawk_source(job_control)
 
-  benchmark = run_benchmark.BenchmarkRunner(job_control)
-  mock_symlink.assert_called_with('source_url__hash_doesnt_really_matter_here__master', 'source_url__hash_doesnt_really_matter_here__master')
+  _ = run_benchmark.BenchmarkRunner(job_control)
+  mock_symlink.has_calls([
+    mock.call('source_url__padawan__master'),
+    mock.call('source_url__jedi__master')]
+  )
 
 @mock.patch('os.symlink')
 @mock.patch.object(full_docker.Benchmark, 'run_image')

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -239,6 +239,7 @@ def test_determine_envoy_hashes_from_source_pull_fail(mock_copy_source_directory
   assert str(source_error.value) == \
     "Unable to obtain the source to determine commit hashes"
 
+
 def test_find_all_images_from_specified_tags():
   """Verify that we can parse an image tag and deterimine the previous
   image tag.
@@ -270,13 +271,16 @@ def test_find_all_images_from_specified_tags():
   }
   assert tags == expected_tags
 
-def test_find_all_images_from_specified_tags_fail():
+@mock.patch.object(source_manager.SourceManager, 'get_source_tree')
+def test_find_all_images_from_specified_tags_fail(mock_source_tree):
   """Verify that we raise an exception if no images are defined for any benchmarks"""
 
   job_control = proto_control.JobControl(
       remote=False,
       scavenging_benchmark=True
   )
+
+  mock_source_tree.return_value = None
 
   manager = source_manager.SourceManager(job_control)
   hashes = []
@@ -285,7 +289,7 @@ def test_find_all_images_from_specified_tags_fail():
 
   assert not hashes
   assert str(source_error.value) == \
-    "No images are specified in the control document"
+    "No images are specified or able to be built from the control document"
 
 def test_find_all_images_from_specified_tags_build_envoy():
   """Verify that return no hashes and if we have to build Envoy"""


### PR DESCRIPTION
Update the README.md to contain an example of the Job Control
for a binary benchmark.  Also update the binary benchmark to
operate on the specified commit and one prior as is inline with
other implemented benchmarks

Signed-off-by: abaptiste <abaptiste@users.noreply.github.com>

cc: @mum4k 