### PR TITLE
[Salvo] Fix typo in salvo/README.md

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -24,7 +24,7 @@ JSON Example:
     "envoyImage": "envoyproxy/envoy:v1.16.0"
   },
   "environment": {
-    "testVersions": IPV_V4ONLY,
+    "testVersion": IPV_V4ONLY,
     "envoyPath": "envoy",
     "outputDir": "/home/ubuntu/nighthawk_output",
     "testDir": "/home/ubuntu/nighthawk_tests"
@@ -41,7 +41,7 @@ environment:
   envoyPath: 'envoy'
   outputDir: '/home/ubuntu/nighthawk_output'
   testDir: '/home/ubuntu/nighthawk_tests'
-  testVersions: IPV_V4ONLY
+  testVersion: IPV_V4ONLY
 images:
   reuseNhImages: true
   nighthawkBenchmarkImage: 'envoyproxy/nighthawk-benchmark-dev:latest'


### PR DESCRIPTION
This small PR fixes a typo in salvo/README.md. Example job control document's field should be singular testVersion instead of testVersions.

Signed-off-by: Sunil Narasimhamurthy <sunnrs@amazon.com>

cc: @mum4k , @abaptiste 