### PR TITLE
[Salvo] Add su-exec docker image dependency to Salvo build process

### DIFF
--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -27,9 +27,14 @@ def _check_call_side_effect(args, parameters):
     return "INFO: Starting clean"
   elif args == "bazel build -c opt " + constants.ENVOY_BINARY_BUILD_TARGET:
     return "building..."
+  elif args == "bazel build -c opt external:su-exec":
+    return "building su-exec ..."
   elif args == ("cp -fv bazel-bin/source/exe/envoy-static "
                 "build_release_stripped/envoy"):
     return "copied..."
+  elif args == ("cp -fv bazel-bin/external/com_github_ncopa_suexec/su-exec "
+                "build_release/su-exec"):
+    return "copying su-exec for Dockerfile..."
   elif args == ("objcopy --strip-debug bazel-bin/source/exe/envoy-static "
                 "build_release_stripped/envoy"):
     return "stripped..."


### PR DESCRIPTION
While testing Salvo with Envoy v1.19.0, the docker image failed to build.  Closer examination showed it failed due to the addition of su-exec as a dependency in this [Envoy PR](https://github.com/envoyproxy/envoy/pull/15204).

This change updates the build process to execute the appropriate target and stage the su-exec binary for the docker image generation.

cc @mum4k 