### PR TITLE
[Salvo] Capture and show error logs when failing to run container 

### DIFF
--- a/salvo/src/lib/docker_management/docker_image.py
+++ b/salvo/src/lib/docker_management/docker_image.py
@@ -181,6 +181,11 @@ class DockerImageController():
     """
 
     client = self._image.get_docker_client()
-    return client.containers.run(image_name, stdout=True,
+    try:
+      return client.containers.run(image_name, stdout=True,
                                  stderr=True, detach=False,
                                  **run_parameters._asdict())
+    except docker.errors.ContainerError as e:
+      error_logs = e.container.logs()
+      log.error(f"Failed to run benchmarking test in image: {image_name}, error message: {e}, container logs: {error_logs}")
+      exit()


### PR DESCRIPTION
Fix #123 

When failing to run benchmarking test in image, the error message is
not informative to show what happened in image. This commit captures and
shows container error logs after error occurs.

After this change, when failing to run containers, it will exit and show container logs:
```
2022-01-20 09:26:18,687: 2161054 [ ERROR] [docker_image] Failed to run benchmarking test in image: envoyproxy/nighthawk-benchmark-dev:latest, error message: Command '['./benchmarks', '--log-cli-level=info', '-vvvv']' in image 'envoyproxy/nighthawk-benchmark-dev:latest' returned non-zero exit status 5: b'', container logs: b'\x1b[1m============================= test session starts ==============================\x1b[0m\r\nplatform linux -- Python 3.8.10, pytest-6.0.1, py-1.11.0, pluggy-0.13.1 -- /usr/bin/python3\r\nrootdir: /usr/local/bin/benchmarks/benchmarks.runfiles/nighthawk/benchmarks\r\nplugins: dependency-0.5.1, forked-1.4.0, xdist-1.34.0\r\n\x1b[1mcollecting ... \x1b[0m\x1b[1m\rcollected 0 items                                                              \x1b[0m\r\n\r\n\x1b[33m============================ \x1b[33mno tests ran\x1b[0m\x1b[33m in 0.03s\x1b[0m\x1b[33m =============================\x1b[0m\r\n'
```