### PR TITLE
[Salvo] Add single test mode in Salvo

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -2,19 +2,26 @@
 
 ## What is Salvo
 
-This is a framework that abstracts executing multiple benchmarks of the Envoy Proxy using [Nighthawk](https://github.com/envoyproxy/nighthawk).
+This is a framework that abstracts executing multiple benchmarks of the Envoy Proxy using 
+[Nighthawk](https://github.com/envoyproxy/nighthawk).
 
 ## Goals of Salvo
 
-Salvo allows Envoy developers to perform A/B testing to monitor performance change of Envoy. Salvo provides the local execution mode allowing developers to run a benchmark on their own machine and also provides the remote execution mode to run a benchmark on a remote machine, such as a remote CI system.
+Salvo allows Envoy developers to perform A/B testing to monitor performance change of Envoy. Salvo
+provides the local execution mode allowing developers to run a benchmark on their own machine and
+also provides the remote execution mode to run a benchmark on a remote machine, such as a remote CI
+system.
 
 ## About this section
 
-This section will give a brief overview of Salvo's building, usage and results. If you want to dive into using Salvo to measure Envoy's performance change with an A/B testing, please read the detailed workflow documentation: [ENVOY_DEVELOP_WORKFLOW.md](./ENVOY_DEVELOP_WORKFLOW.md)
+This section will give a brief overview of Salvo's building, usage and results. If you want to dive
+into using Salvo to measure Envoy's performance change with an A/B testing, please read the detailed
+workflow documentation: [ENVOY_DEVELOP_WORKFLOW.md](./ENVOY_DEVELOP_WORKFLOW.md)
 
 ## Dependencies
 
-The [`install_deps.sh`](./install_deps.sh) script can be used to install any dependencies required by Salvo.
+The [`install_deps.sh`](./install_deps.sh) script can be used to install any dependencies required
+by Salvo.
 
 ## Building Salvo
 
@@ -26,15 +33,21 @@ bazel build //...
 
 ## Benchmark Test Cases for Salvo
 
-Benchmark test cases for Salvo are defined as Python files with test cases written in pytest framework, here is an example: https://github.com/envoyproxy/nighthawk/blob/main/benchmarks/test/test_discovery.py. Users can provide their own Python files of test cases into Salvo.
+Benchmark test cases for Salvo are defined as Python files with test cases written in pytest
+framework, here is an example:
+https://github.com/envoyproxy/nighthawk/blob/main/benchmarks/test/test_discovery.py. Users can
+provide their own Python files of test cases into Salvo.
 
 ## Control Documents
 
-The control document defines the data needed to execute a benchmark. We support the fully dockerized benchmark, the scavenging benchmark and the binary benchmark. 
+The control document defines the data needed to execute a benchmark. We support the fully dockerized
+benchmark, the scavenging benchmark and the binary benchmark. 
 
 ### Fully Dockerized Benchmark
 
-The Fully Dockerized Benchmark discoveres user supplied tests for execution and uses docker images to run the tests. In the example below, the user supplied tests files are located in `/home/ubuntu/nighthawk_tests` and are mapped to a volume in the docker container.
+The Fully Dockerized Benchmark discoveres user supplied tests for execution and uses docker images
+to run the tests. In the example below, the user supplied tests files are located in
+`/home/ubuntu/nighthawk_tests` and are mapped to a volume in the docker container.
 
 To run the dockerized benchmark, create a file with the following example contents:
 
@@ -82,9 +95,13 @@ images:
 
 `environment.outputDir`: The directory where benchmark results will be placed.
 
-`environment.testDir`: The directory where test case files placed, it's optional. If you want to provide your own test cases, put test files like [this one](https://github.com/envoyproxy/nighthawk/blob/main/benchmarks/test/test_discovery.py) into the testDir.
+`environment.testDir`: The directory where test case files placed, it's optional. If you want to
+provide your own test cases, put test files like
+[this one](https://github.com/envoyproxy/nighthawk/blob/main/benchmarks/test/test_discovery.py)
+into the testDir.
 
-`environment.testVersion`: Specify the ip address family to use, choose from "IPV_V4ONLY", "IPV_V6ONLY" and "ALL".
+`environment.testVersion`: Specify the ip address family to use, choose from "IPV_V4ONLY",
+"IPV_V6ONLY" and "ALL".
 
 `environment.envoyPath`: Envoy is called 'Envoy' in the Envoy Docker image.
 
@@ -94,13 +111,25 @@ images:
 
 `images.nighthawkBinaryImage`: Nighthawk tools will be sourced from this Docker image.
 
-`images.envoyImage`: The specific Envoy docker image to test. If only `images.envoyImage` is defined, we will find the previous image built from the prior tag. If you want to specify additional images for which we benchmark for analysis, specify a list of image strings at `images.additional_envoy_images` filed, eg: [ "envoyproxy/envoy-dev:7da2adee8962c202999e96cb41e899deb34faf48",..]. If you only want to test the specified envoy image, specify `images.test_single_image` as `True`. `images.additional_envoy_images` and `images.test_single_image` cannot be defined at the same time.
+`images.envoyImage`: The specific Envoy docker image to test. If only `images.envoyImage` is
+defined, we will find the previous image built from the prior tag. If you want to specify additional
+images for which we benchmark for analysis, specify a list of image strings at
+`images.additional_envoy_images` filed,
+eg: [ "envoyproxy/envoy-dev:7da2adee8962c202999e96cb41e899deb34faf48",..].
+If you only want to test the specified envoy image, specify `images.test_single_image` as `True`.
+`images.additional_envoy_images` and `images.test_single_image` cannot be defined at the same time.
 
-In both examples above, the envoy image being tested is a specific tag. This tag can be replaced with "latest" to test the most recently created image against the previous image built from the prior tag. If a commit hash is used, we find the previous commit hash and benchmark that container. In summary, tags are compared to tags, hashes are compared to hashes.
+In both examples above, the envoy image being tested is a specific tag. This tag can be replaced
+with "latest" to test the most recently created image against the previous image built from the
+prior tag. If a commit hash is used, we find the previous commit hash and benchmark that container.
+In summary, tags are compared to tags, hashes are compared to hashes.
 
 ### Scavenging Benchmark
 
-The Scavenging Benchmark builds and runs [Nighthawk benchmark testsuite](https://github.com/envoyproxy/nighthawk/tree/main/benchmarks) on the local machine and uses a specified Envoy image for testing. Tests are discovered in the specified directory in the Environment object:
+The Scavenging Benchmark builds and runs
+[Nighthawk benchmark testsuite](https://github.com/envoyproxy/nighthawk/tree/main/benchmarks) on the
+local machine and uses a specified Envoy image for testing. Tests are discovered in the specified
+directory in the Environment object:
 
 ```yaml
 remote: false
@@ -124,11 +153,16 @@ source:
 
 `source.identity`: Specify whether this source location is Envoy or Nighthawk.
 
-In this example, the v1.21.0 Envoy tag is pulled and an Envoy image generated where the Envoy binary has profiling enabled. The user may specify option strings supported by bazel to adjust the compilation process.
+In this example, the v1.21.0 Envoy tag is pulled and an Envoy image generated where the Envoy binary
+has profiling enabled. The user may specify option strings supported by bazel to adjust the
+compilation process.
 
 ### Binary Benchmark
 
-The binary benchmark runs an envoy binary as the test target.  The binary is compiled from the source commit specified. As is the case with other benchmarks as well, the previous commit is deduced and a benchmark is executed for these code points. All Nighthawk components are built from source. This benchmark runs on the local host directly.
+The binary benchmark runs an envoy binary as the test target.  The binary is compiled from the
+source commit specified. As is the case with other benchmarks as well, the previous commit is
+deduced and a benchmark is executed for these code points. All Nighthawk components are built from
+source. This benchmark runs on the local host directly.
 
 Example Job Control specification for executing a binary benchmark:
 
@@ -155,9 +189,16 @@ source:
 
 `binaryBenchmark`: It will run binary benchmarks.
 
-`source.commit_hash`: Specify a commit hash if applicable. If not specified we will determine this from the source tree. We will also use this field to identify the corresponding Nighthawk or Envoy image used for the benchmark. If only `source.commit_hash`is defined, we will find the previous commit hash. If you want to specify additional commit hashes for which we benchmark for analysis, specify a list of commit hashes strings at `source.additional_hashes` filed, eg: [ "b435d3a3baa39f1a15cd68625da085cfa16ae957",..]. If you only want to test the specified envoy commit, specify `source.test_single_commit` as `True`. `source.additional_hashes` and `source.test_single_commit` cannot be defined at the same time.
+`source.commit_hash`: Specify a commit hash if applicable. If not specified we will determine this
+from the source tree. We will also use this field to identify the corresponding Nighthawk or Envoy
+image used for the benchmark. If only `source.commit_hash`is defined, we will find the previous
+commit hash. If you want to specify additional commit hashes for which we benchmark for analysis,
+specify a list of commit hashes strings at `source.additional_hashes` filed, eg: [ "b435d3a3baa39f1a15cd68625da085cfa16ae957",..]. If you only want to test the specified envoy commit,
+specify `source.test_single_commit` as `True`. `source.additional_hashes` and
+`source.test_single_commit` cannot be defined at the same time.
 
-`source.BazelOption`: A list of compiler options and flags to supply to bazel when building the source of Nighthawk or Envoy. 
+`source.BazelOption`: A list of compiler options and flags to supply to bazel when building the
+source of Nighthawk or Envoy. 
 
 
 ## Running Salvo
@@ -168,7 +209,8 @@ The resulting 'binary' in the bazel-bin directory can then be invoked with a job
 bazel-bin/salvo --job <path to>/demo_jobcontrol.yaml
 ```
 
-Salvo creates a symlink in the local directory to the location of the  output artifacts for each Envoy version tested.
+Salvo creates a symlink in the local directory to the location of the  output artifacts for each
+Envoy version tested.
 
 ## Example Benchmark outputs of Salvo
 
@@ -260,7 +302,8 @@ upstream_rq_total                       30000       1000.00
 
 ## Testing Salvo
 
-From the envoy-perf project directory, run the do_ci.sh script with the "test" argument. Since this installs packages packages, it will need to be run as root.
+From the envoy-perf project directory, run the do_ci.sh script with the "test" argument. Since this
+installs packages packages, it will need to be run as root.
 
 To test Salvo itself, change into the salvo directory and use:
 

--- a/salvo/README.md
+++ b/salvo/README.md
@@ -94,7 +94,7 @@ images:
 
 `images.nighthawkBinaryImage`: Nighthawk tools will be sourced from this Docker image.
 
-`images.envoyImage`: The specific Envoy docker image to test.
+`images.envoyImage`: The specific Envoy docker image to test. If only `images.envoyImage` is defined, we will find the previous image built from the prior tag. If you want to specify additional images for which we benchmark for analysis, specify a list of image strings at `images.additional_envoy_images` filed, eg: [ "envoyproxy/envoy-dev:7da2adee8962c202999e96cb41e899deb34faf48",..]. If you only want to test the specified envoy image, specify `images.test_single_image` as `True`. `images.additional_envoy_images` and `images.test_single_image` cannot be defined at the same time.
 
 In both examples above, the envoy image being tested is a specific tag. This tag can be replaced with "latest" to test the most recently created image against the previous image built from the prior tag. If a commit hash is used, we find the previous commit hash and benchmark that container. In summary, tags are compared to tags, hashes are compared to hashes.
 
@@ -155,7 +155,7 @@ source:
 
 `binaryBenchmark`: It will run binary benchmarks.
 
-`source.commit_hash`: Specify a commit hash if applicable. If not specified we will determine this from the source tree. We will also use this field to identify the corresponding Nighthawk or Envoy image used for the benchmark.
+`source.commit_hash`: Specify a commit hash if applicable. If not specified we will determine this from the source tree. We will also use this field to identify the corresponding Nighthawk or Envoy image used for the benchmark. If only `source.commit_hash`is defined, we will find the previous commit hash. If you want to specify additional commit hashes for which we benchmark for analysis, specify a list of commit hashes strings at `source.additional_hashes` filed, eg: [ "b435d3a3baa39f1a15cd68625da085cfa16ae957",..]. If you only want to test the specified envoy commit, specify `source.test_single_commit` as `True`. `source.additional_hashes` and `source.test_single_commit` cannot be defined at the same time.
 
 `source.BazelOption`: A list of compiler options and flags to supply to bazel when building the source of Nighthawk or Envoy. 
 

--- a/salvo/api/image.proto
+++ b/salvo/api/image.proto
@@ -34,4 +34,10 @@ message DockerImages {
   // defined and benchmark the discovered image.
   // eg: [ "envoyproxy/envoy-dev:7da2adee8962c202999e96cb41e899deb34faf48",..]
   repeated string additional_envoy_images = 5;
+
+  // If this field is ture and additional_envoy_images is not defined, we will
+  // only test envoy_image which is defined in envoy_image field. It's useful
+  // for the scenario that someone want to test different configuration with 
+  // specific envoy image.
+  bool test_single_image = 6;
 }

--- a/salvo/api/image.proto
+++ b/salvo/api/image.proto
@@ -36,7 +36,7 @@ message DockerImages {
   repeated string additional_envoy_images = 5;
 
   // If this field is ture and additional_envoy_images is not defined, we will
-  // only test envoy_image which is defined in envoy_image field. It's useful
+  // only test envoy image which is defined in envoy_image field. It's useful
   // for the scenario that someone want to test different configuration with 
   // specific envoy image.
   bool test_single_image = 6;

--- a/salvo/api/image.proto
+++ b/salvo/api/image.proto
@@ -35,9 +35,10 @@ message DockerImages {
   // eg: [ "envoyproxy/envoy-dev:7da2adee8962c202999e96cb41e899deb34faf48",..]
   repeated string additional_envoy_images = 5;
 
-  // If this field is ture and additional_envoy_images is not defined, we will
+  // If this field is true and additional_envoy_images is not defined, we will
   // only test envoy image which is defined in envoy_image field. It's useful
   // for the scenario that someone want to test different configuration with 
-  // specific envoy image.
+  // specific envoy image. test_single_image and additional_envoy_images are
+  // mutually exclusive and cannot be defined at the same time.
   bool test_single_image = 6;
 }

--- a/salvo/api/source.proto
+++ b/salvo/api/source.proto
@@ -54,9 +54,10 @@ message SourceRepository {
   // the source of NightHawk or Envoy
   repeated BazelOption bazel_options = 7;
 
-  // If this field is ture and additional_hashes is not defined, we will
+  // If this field is true and additional_hashes is not defined, we will
   // only test envoy commit which is defined in commit_hash field. It's useful
   // for the scenario that someone want to test different configuration with 
-  // specific envoy commit.
+  // specific envoy commit. test_single_commit and additional_hashes are
+  // mutually exclusive and cannot be defined at the same time
   bool test_single_commit = 8;
 }

--- a/salvo/api/source.proto
+++ b/salvo/api/source.proto
@@ -54,9 +54,9 @@ message SourceRepository {
   // the source of NightHawk or Envoy
   repeated BazelOption bazel_options = 7;
 
-  // If this field is ture and additional_envoy_images is not defined, we will
-  // only test envoy_image which is defined in envoy_image field. It's useful
+  // If this field is ture and additional_hashes is not defined, we will
+  // only test envoy commit which is defined in commit_hash field. It's useful
   // for the scenario that someone want to test different configuration with 
-  // specific envoy image.
+  // specific envoy commit.
   bool test_single_commit = 8;
 }

--- a/salvo/api/source.proto
+++ b/salvo/api/source.proto
@@ -53,4 +53,10 @@ message SourceRepository {
   // A list of compiler options and flags to supply to bazel when building
   // the source of NightHawk or Envoy
   repeated BazelOption bazel_options = 7;
+
+  // If this field is ture and additional_envoy_images is not defined, we will
+  // only test envoy_image which is defined in envoy_image field. It's useful
+  // for the scenario that someone want to test different configuration with 
+  // specific envoy image.
+  bool test_single_commit = 8;
 }

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -188,8 +188,6 @@ class SourceManager(object):
     if additional_hashes:
       hash_set = hash_set.union(additional_hashes)
 
-    # If additional_hashes are specified, return them and source repo commit
-    # If test_single_commit are specified, just return source repo commit
     if source_repo.commit_hash and (additional_hashes or test_single_commit):
       hash_set = hash_set.union([source_repo.commit_hash])
       return hash_set

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -14,9 +14,9 @@ log = logging.getLogger(__name__)
    source code needed to build Envoy and NightHawk
 """
 _KNOWN_REPOSITORIES = {
-    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:  \
+    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:   \
       constants.ENVOY_GITHUB_REPO,
-    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:  \
+    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:   \
       constants.NIGHTHAWK_GITHUB_REPO
 }
 
@@ -180,7 +180,7 @@ class SourceManager(object):
     source_repo = self.get_source_repository(proto_source.SourceRepository.SRCID_ENVOY)
 
     # We have a source, see whether additional hashes are specified
-    test_single_commit= source_repo.test_single_commit
+    test_single_commit = source_repo.test_single_commit
     additional_hashes = source_repo.additional_hashes
     if test_single_commit and additional_hashes:
       raise SourceManagerError(

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -265,6 +265,7 @@ def test_find_all_images_from_specified_tags_fail(mock_source_tree):
   assert str(source_error.value) == \
     "No images are specified or able to be built from the control document"
 
+
 def test_find_image_single():
   """Verify that we can just find specific image with test_single_image enabled"""
   job_control = proto_control.JobControl(
@@ -275,20 +276,19 @@ def test_find_image_single():
   _generate_default_benchmark_images(job_control)
 
   # Add an envoy image and specify additional versions to test
-  job_control.images.envoy_image="envoyproxy/envoy:v1.16.0"
+  job_control.images.envoy_image = "envoyproxy/envoy:v1.16.0"
 
   # Specify test_single_image as true
-  job_control.images.test_single_image=True
+  job_control.images.test_single_image = True
 
   manager = source_manager.SourceManager(job_control)
 
   tags = manager.find_all_images_from_specified_tags()
 
   # We test all extra tags first and the specified image tags is always last
-  expected_tags = {
-      'v1.16.0'
-  }
+  expected_tags = {'v1.16.0'}
   assert tags == expected_tags
+
 
 @mock.patch.object(source_manager.SourceManager, 'get_source_tree')
 def test_find_image_single_fail(mock_source_tree):
@@ -303,15 +303,13 @@ def test_find_image_single_fail(mock_source_tree):
   _generate_default_benchmark_images(job_control)
 
   # Add an envoy image and specify additional versions to test
-  job_control.images.envoy_image="envoyproxy/envoy:v1.16.0"
+  job_control.images.envoy_image = "envoyproxy/envoy:v1.16.0"
 
   # Specify test_single_image as true
-  job_control.images.test_single_image=True
+  job_control.images.test_single_image = True
 
-  for index in range(1,4):
-    job_control.images.additional_envoy_images.append(
-        "envoyproxy/envoy:tag{i}".format(i=index)
-    )
+  for index in range(1, 4):
+    job_control.images.additional_envoy_images.append("envoyproxy/envoy:tag{i}".format(i=index))
 
   manager = source_manager.SourceManager(job_control)
 
@@ -324,6 +322,7 @@ def test_find_image_single_fail(mock_source_tree):
   assert not hashes
   assert str(source_error.value) == \
     '"additional_envoy_image" cannot be set with "test_single_image" enabled'
+
 
 def test_find_all_images_from_specified_tags_build_envoy():
   """Verify that return no hashes and if we have to build Envoy"""
@@ -415,25 +414,18 @@ def test_get_envoy_hashes_for_benchmark_additional_hashes(mock_copy_source_direc
 
 @mock.patch("src.lib.cmd_exec.run_command")
 @mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
-<<<<<<< HEAD
-def test_get_image_hashes_from_disk_source(mock_copy_source_directory, mock_run_command):
-=======
-def test_find_all_images_from_specified_sources_single(
-                                                mock_copy_source_directory,
-                                                mock_run_command):
+def test_find_all_images_from_specified_sources_single(mock_copy_source_directory,
+                                                       mock_run_command):
   """Verify that we raise an exception if both test_single_commit and
   additional_hashes are set
    """
-  job_control = proto_control.JobControl(
-      remote=False,
-      scavenging_benchmark=True
-  )
+  job_control = proto_control.JobControl(remote=False, scavenging_benchmark=True)
 
   _generate_default_benchmark_images(job_control)
   _generate_default_envoy_source(job_control)
 
   # Specify test_single_commit as true
-  job_control.source[0].test_single_commit=True
+  job_control.source[0].test_single_commit = True
 
   # Setup mocks
   mock_copy_source_directory.return_value = True
@@ -441,38 +433,31 @@ def test_find_all_images_from_specified_sources_single(
 
   manager = source_manager.SourceManager(job_control)
   hashes = manager.find_all_images_from_specified_sources()
-  expected_hashes = {
-      'expected_baseline_hash'
-  }
+  expected_hashes = {'expected_baseline_hash'}
   assert hashes == expected_hashes
+
 
 @mock.patch("src.lib.cmd_exec.run_command")
 @mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
-def test_find_all_images_from_specified_sources_single_fail(
-                                                mock_copy_source_directory,
-                                                mock_run_command):
+def test_find_all_images_from_specified_sources_single_fail(mock_copy_source_directory,
+                                                            mock_run_command):
   """Verify that we can deterimine commit hash from a source tree
   with single mode enabled.
   """
-  job_control = proto_control.JobControl(
-      remote=False,
-      scavenging_benchmark=True
-  )
+  job_control = proto_control.JobControl(remote=False, scavenging_benchmark=True)
 
   _generate_default_benchmark_images(job_control)
   _generate_default_envoy_source(job_control)
 
   # Specify test_single_commit as true
-  job_control.source[0].test_single_commit=True
+  job_control.source[0].test_single_commit = True
 
   # Setup mocks
   mock_copy_source_directory.return_value = True
   mock_run_command.side_effect = _run_command_side_effect
 
-  for index in range(1,4):
-    job_control.source[0].additional_hashes.append(
-      "02dff6e0235e2f497fb57eb0b7c07cc091c538df"
-    )
+  for index in range(1, 4):
+    job_control.source[0].additional_hashes.append("02dff6e0235e2f497fb57eb0b7c07cc091c538df")
 
   manager = source_manager.SourceManager(job_control)
 
@@ -483,11 +468,10 @@ def test_find_all_images_from_specified_sources_single_fail(
   assert str(source_error.value) == \
     '"additional_hashes" cannot be set with "test_single_commit" enabled'
 
+
 @mock.patch("src.lib.cmd_exec.run_command")
 @mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
-def test_get_image_hashes_from_disk_source(mock_copy_source_directory,
-                                           mock_run_command):
->>>>>>> [Salvo] Add single test mode in Salvo
+def test_get_image_hashes_from_disk_source(mock_copy_source_directory, mock_run_command):
   """Verify that we can determine previous hash for a specified commit."""
 
   job_control = proto_control.JobControl(remote=False, scavenging_benchmark=True)

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -265,6 +265,65 @@ def test_find_all_images_from_specified_tags_fail(mock_source_tree):
   assert str(source_error.value) == \
     "No images are specified or able to be built from the control document"
 
+def test_find_image_single():
+  """Verify that we can just find specific image with test_single_image enabled"""
+  job_control = proto_control.JobControl(
+      remote=False,
+      scavenging_benchmark=True,
+  )
+
+  _generate_default_benchmark_images(job_control)
+
+  # Add an envoy image and specify additional versions to test
+  job_control.images.envoy_image="envoyproxy/envoy:v1.16.0"
+
+  # Specify test_single_image as true
+  job_control.images.test_single_image=True
+
+  manager = source_manager.SourceManager(job_control)
+
+  tags = manager.find_all_images_from_specified_tags()
+
+  # We test all extra tags first and the specified image tags is always last
+  expected_tags = {
+      'v1.16.0'
+  }
+  assert tags == expected_tags
+
+@mock.patch.object(source_manager.SourceManager, 'get_source_tree')
+def test_find_image_single_fail(mock_source_tree):
+  """Verify that we raise an exception if both test_single_image and
+  additional_images are set
+   """
+  job_control = proto_control.JobControl(
+      remote=False,
+      scavenging_benchmark=True,
+  )
+
+  _generate_default_benchmark_images(job_control)
+
+  # Add an envoy image and specify additional versions to test
+  job_control.images.envoy_image="envoyproxy/envoy:v1.16.0"
+
+  # Specify test_single_image as true
+  job_control.images.test_single_image=True
+
+  for index in range(1,4):
+    job_control.images.additional_envoy_images.append(
+        "envoyproxy/envoy:tag{i}".format(i=index)
+    )
+
+  manager = source_manager.SourceManager(job_control)
+
+  mock_source_tree.return_value = None
+
+  hashes = []
+  with pytest.raises(source_manager.SourceManagerError) as source_error:
+    hashes = manager.find_all_images_from_specified_tags()
+
+  assert not hashes
+  assert str(source_error.value) == \
+    '"additional_envoy_image" cannot be set with "test_single_image" enabled'
 
 def test_find_all_images_from_specified_tags_build_envoy():
   """Verify that return no hashes and if we have to build Envoy"""
@@ -356,7 +415,79 @@ def test_get_envoy_hashes_for_benchmark_additional_hashes(mock_copy_source_direc
 
 @mock.patch("src.lib.cmd_exec.run_command")
 @mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
+<<<<<<< HEAD
 def test_get_image_hashes_from_disk_source(mock_copy_source_directory, mock_run_command):
+=======
+def test_find_all_images_from_specified_sources_single(
+                                                mock_copy_source_directory,
+                                                mock_run_command):
+  """Verify that we raise an exception if both test_single_commit and
+  additional_hashes are set
+   """
+  job_control = proto_control.JobControl(
+      remote=False,
+      scavenging_benchmark=True
+  )
+
+  _generate_default_benchmark_images(job_control)
+  _generate_default_envoy_source(job_control)
+
+  # Specify test_single_commit as true
+  job_control.source[0].test_single_commit=True
+
+  # Setup mocks
+  mock_copy_source_directory.return_value = True
+  mock_run_command.side_effect = _run_command_side_effect
+
+  manager = source_manager.SourceManager(job_control)
+  hashes = manager.find_all_images_from_specified_sources()
+  expected_hashes = {
+      'expected_baseline_hash'
+  }
+  assert hashes == expected_hashes
+
+@mock.patch("src.lib.cmd_exec.run_command")
+@mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
+def test_find_all_images_from_specified_sources_single_fail(
+                                                mock_copy_source_directory,
+                                                mock_run_command):
+  """Verify that we can deterimine commit hash from a source tree
+  with single mode enabled.
+  """
+  job_control = proto_control.JobControl(
+      remote=False,
+      scavenging_benchmark=True
+  )
+
+  _generate_default_benchmark_images(job_control)
+  _generate_default_envoy_source(job_control)
+
+  # Specify test_single_commit as true
+  job_control.source[0].test_single_commit=True
+
+  # Setup mocks
+  mock_copy_source_directory.return_value = True
+  mock_run_command.side_effect = _run_command_side_effect
+
+  for index in range(1,4):
+    job_control.source[0].additional_hashes.append(
+      "02dff6e0235e2f497fb57eb0b7c07cc091c538df"
+    )
+
+  manager = source_manager.SourceManager(job_control)
+
+  hashes = []
+  with pytest.raises(source_manager.SourceManagerError) as source_error:
+    hashes = manager.find_all_images_from_specified_sources()
+  assert not hashes
+  assert str(source_error.value) == \
+    '"additional_hashes" cannot be set with "test_single_commit" enabled'
+
+@mock.patch("src.lib.cmd_exec.run_command")
+@mock.patch.object(source_tree.SourceTree, 'copy_source_directory')
+def test_get_image_hashes_from_disk_source(mock_copy_source_directory,
+                                           mock_run_command):
+>>>>>>> [Salvo] Add single test mode in Salvo
   """Verify that we can determine previous hash for a specified commit."""
 
   job_control = proto_control.JobControl(remote=False, scavenging_benchmark=True)


### PR DESCRIPTION
Fix #132. Add `test_single_image` and `test_single_commit` option to enable single test mode, which is helpful to the scenario that someone want to test different configuration based on one specific envoy image/commit.