### PR TITLE
Improve CI coverage for Salvo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,20 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh test
+  check-format:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh check_format
+  coverage:
+    docker:
+      - image: *envoy-build-image
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: ci/do_ci.sh coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh test
-  check-format:
+  check_format:
     docker:
       - image: *envoy-build-image
     resource_class: xlarge
@@ -39,3 +39,5 @@ workflows:
     jobs:
       - build
       - test
+      - check_format
+      - unit_tests_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - run: ci/do_ci.sh check_format
-  coverage:
+  unit_tests_coverage:
     docker:
       - image: *envoy-build-image
     resource_class: xlarge

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -49,6 +49,7 @@ function fix_format() {
   echo "Fixing the Salvo python files format"
   pushd salvo
 
+  install_deps
   tools/format_python_tools.sh fix 
 
   popd
@@ -59,7 +60,9 @@ function coverage() {
   echo "Calcuting the Salvo unit tests coverage"
   pushd salvo
 
+  ehco "Setting the minimum threshold of coverage to 99%"
   export MINIMUM_THRESHOLD=99
+  install_deps
   tools/coverage.sh
 
   popd

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -60,7 +60,7 @@ function coverage() {
   echo "Calcuting the Salvo unit tests coverage"
   pushd salvo
 
-  export MINIMUM_THRESHOLD=99
+  export MINIMUM_THRESHOLD=98
   echo "Setting the minimum threshold of coverage to ${MINIMUM_THRESHOLD}%"
   install_deps
   tools/coverage.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -56,9 +56,10 @@ function fix_format() {
 
 # Calacute Salvo test coverage
 function coverage() {
-  echo "Calcuting the Salvo test coverage"
+  echo "Calcuting the Salvo unit tests coverage"
   pushd salvo
 
+  export MINIMUM_THRESHOLD=99
   tools/coverage.sh
 
   popd
@@ -85,6 +86,8 @@ case $build_target in
     coverage
     ;;
   *)
+    echo "must be one of [build, test, check_format, fix_format, coverage]"
+    exit 1
     ;;
 esac
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -60,7 +60,7 @@ function coverage() {
   echo "Calcuting the Salvo unit tests coverage"
   pushd salvo
 
-  ehco "Setting the minimum threshold of coverage to 99%"
+  echo "Setting the minimum threshold of coverage to 99%"
   export MINIMUM_THRESHOLD=99
   install_deps
   tools/coverage.sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -34,6 +34,35 @@ function test_salvo() {
   popd
 }
 
+# Check the Salvo python files format
+function check_format() {
+  echo "Checking the Salvo python files format"
+  pushd salvo
+
+  tools/format_python_tools.sh check
+
+  popd
+}
+
+# Fix the Salvo python files format
+function fix_format() {
+  echo "Fixing the Salvo python files format"
+  pushd salvo
+
+  tools/format_python_tools.sh fix 
+
+  popd
+}
+
+# Calacute Salvo test coverage
+function coverage() {
+  echo "Calcuting the Salvo test coverage"
+  pushd salvo
+
+  tools/coverage.sh
+
+  popd
+}
 
 # Set the build target. If no parameters are specified
 # we default to "build"
@@ -45,6 +74,15 @@ case $build_target in
     ;;
   "test")
     test_salvo
+    ;;
+  "check_format")
+    check_format
+    ;;
+  "fix_format")
+    fix_format
+    ;;
+  "coverage")
+    coverage
     ;;
   *)
     ;;

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -60,8 +60,8 @@ function coverage() {
   echo "Calcuting the Salvo unit tests coverage"
   pushd salvo
 
-  echo "Setting the minimum threshold of coverage to 99%"
   export MINIMUM_THRESHOLD=99
+  echo "Setting the minimum threshold of coverage to ${MINIMUM_THRESHOLD}%"
   install_deps
   tools/coverage.sh
 

--- a/salvo/src/lib/benchmark/binary_benchmark.py
+++ b/salvo/src/lib/benchmark/binary_benchmark.py
@@ -85,12 +85,12 @@ class Benchmark(base_benchmark.BaseBenchmark):
       if source_def.identity == source_def.SRCID_UNSPECIFIED:
         raise BinaryBenchmarkError("No source identity specified")
 
-      if source_def.identity == source_def.SRCID_ENVOY and \
-        (source_def.source_path or source_def.source_url):
+      if source_def.identity == source_def.SRCID_ENVOY and (source_def.source_path or
+                                                            source_def.source_url):
         can_build_envoy = True
 
-      if source_def.identity == source_def.SRCID_NIGHTHAWK and \
-        (source_def.source_path or source_def.source_url):
+      if source_def.identity == source_def.SRCID_NIGHTHAWK and (source_def.source_path or
+                                                                source_def.source_url):
         can_build_nighthawk = True
 
     if not can_build_nighthawk:
@@ -122,8 +122,8 @@ class Benchmark(base_benchmark.BaseBenchmark):
       BinaryBenchmarkError: an invalid envoy binary is specified via ENVOY_PATH
     """
     if self._envoy_binary_path:
-      if not (os.path.exists(self._envoy_binary_path) \
-          and os.access(self._envoy_binary_path, os.X_OK)):
+      if not (os.path.exists(self._envoy_binary_path) and
+              os.access(self._envoy_binary_path, os.X_OK)):
         raise BinaryBenchmarkError("ENVOY_PATH environment variable specified, but invalid")
       # We already have a binary, no need to build
       log.info("Using Envoy binary specified in ENVOY_PATH environment variable")
@@ -143,7 +143,7 @@ class Benchmark(base_benchmark.BaseBenchmark):
     self._prepare_nighthawk()
     self._prepare_envoy()
 
-    #todo: refactor args, have frontend specify them via protobuf
+    # todo: refactor args, have frontend specify them via protobuf
     cmd = ("bazel test "
            "--test_summary=detailed "
            "--test_output=all "

--- a/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
+++ b/salvo/src/lib/benchmark/fully_dockerized_benchmark.py
@@ -115,6 +115,6 @@ class Benchmark(base_benchmark.BaseBenchmark):
     # Establishing success here requires that we examine the output produced by
     # NightHawk. If the latency output exists we can be relatively certain that
     # all containers were able to run and execute the specified tests
-    if not "benchmark_http_client" in result.decode('utf-8'):
+    if "benchmark_http_client" not in result.decode('utf-8'):
       raise base_benchmark.BenchmarkError(
           "Unable to assert that the benchmark executed successfully")

--- a/salvo/src/lib/builder/base_builder.py
+++ b/salvo/src/lib/builder/base_builder.py
@@ -82,8 +82,7 @@ class BaseBuilder():
     output = cmd_exec.run_command(cmd, cmd_params)
     log.debug(f"Clean output: {output}")
 
-  def _generate_bazel_options(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) -> str:
+  def _generate_bazel_options(self, source_id: proto_source.SourceRepository.SourceIdentity) -> str:
     """Generate the options string that we supply to bazel when building
       Envoy or NightHawk.
 

--- a/salvo/src/lib/docker_management/docker_image.py
+++ b/salvo/src/lib/docker_management/docker_image.py
@@ -123,8 +123,7 @@ class DockerImage():
   def list_processes(self) -> List[str]:
     """List running containers."""
     image_filter = {'status': 'running'}
-    return [container.name for container in \
-        self._client.containers.list(filters=image_filter)]
+    return [container.name for container in self._client.containers.list(filters=image_filter)]
 
   def stop_image(self, image_name: str) -> None:
     """Stops a running container."""

--- a/salvo/src/lib/docker_management/docker_image_builder.py
+++ b/salvo/src/lib/docker_management/docker_image_builder.py
@@ -114,8 +114,7 @@ def get_envoy_image_prefix(image_hash: str) -> str:
   Returns:
     The prefix used to generate the full Envoy docker image name
   """
-  return "envoyproxy/envoy" if source_tree.is_tag(image_hash) \
-    else "envoyproxy/envoy-dev"
+  return "envoyproxy/envoy" if source_tree.is_tag(image_hash) else "envoyproxy/envoy-dev"
 
 
 def build_nighthawk_benchmark_image_from_source(manager: source_manager.SourceManager) -> None:

--- a/salvo/src/lib/docker_management/test_docker_image.py
+++ b/salvo/src/lib/docker_management/test_docker_image.py
@@ -73,8 +73,7 @@ def test_list_images(mock_list_images):
   """Verify that we can list all existing cached docker images."""
 
   expected_image_tags = ['image:1', 'image:2', 'image:3']
-  mock_list_images.return_value = \
-    map(lambda tag: mock.Mock(tags=[tag]), expected_image_tags)
+  mock_list_images.return_value = map(lambda tag: mock.Mock(tags=[tag]), expected_image_tags)
 
   new_docker_image = docker_image.DockerImage()
   images = new_docker_image.list_images()

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -115,8 +115,7 @@ class BenchmarkRunner(object):
 
     return job_control_list
 
-  def _generate_job_control_for_binaries(self) \
-    -> List[proto_control.JobControl]:
+  def _generate_job_control_for_binaries(self) -> List[proto_control.JobControl]:
     """Determine the required source configurations needed for a binary benchmark.
 
     Find the specified version of Nighthawk, Envoy, and all additional Envoy
@@ -139,8 +138,8 @@ class BenchmarkRunner(object):
     if not nighthawk_source:
       raise BenchmarkRunnerError("No Nighthawk sources specified")
 
-    log.info("Using Nighthawk sources at " \
-      + getattr(nighthawk_source, nighthawk_source.WhichOneof('source_location')))
+    log.info("Using Nighthawk sources at " +
+             getattr(nighthawk_source, nighthawk_source.WhichOneof('source_location')))
 
     base_envoy_source = self._source_manager.get_source_repository(
         proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY)
@@ -156,9 +155,7 @@ class BenchmarkRunner(object):
 
     return jobs
 
-  def _pull_or_build_nh_benchmark_image(self, \
-                                        images: proto_image.DockerImages) \
-                                        -> None:
+  def _pull_or_build_nh_benchmark_image(self, images: proto_image.DockerImages) -> None:
     """Attempt to pull the NightHawk Benchmark Image.  Build the image if
        unavailable.
 
@@ -282,8 +279,8 @@ class BenchmarkRunner(object):
 
     return new_job_control
 
-  def _create_new_source_job_control(self, nh_source, envoy_source, envoy_hash) \
-    -> proto_control.JobControl:
+  def _create_new_source_job_control(self, nh_source, envoy_source,
+                                     envoy_hash) -> proto_control.JobControl:
     """Duplicate the job control for a specific benchmark run.
     This method creates a new job control object for a single binary benchmark
     Args:

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -74,7 +74,7 @@ class SourceManager(object):
 
     result = envoy_source_tree.pull()
     if not result:
-      log.error(f"Unable to pull source from origin.  Copying source instead")
+      log.error("Unable to pull source from origin.  Copying source instead")
       result = envoy_source_tree.copy_source_directory()
 
     if not result:
@@ -146,8 +146,7 @@ class SourceManager(object):
       raise SourceManagerError(
           '"additional_envoy_image" cannot be set with "test_single_image" enabled')
     if additional_images:
-      additional_tags = [_extract_tag_from_image(image) \
-          for image in images.additional_envoy_images]
+      additional_tags = [_extract_tag_from_image(image) for image in images.additional_envoy_images]
 
       # Do not add hashes that we have already discovered
       hash_set = hash_set.union(additional_tags)
@@ -251,9 +250,9 @@ class SourceManager(object):
 
     return set([previous_hash, commit_hash])
 
-  def get_source_repository(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) \
-      -> proto_source.SourceRepository:
+  def get_source_repository(
+      self,
+      source_id: proto_source.SourceRepository.SourceIdentity) -> proto_source.SourceRepository:
     """Find and return the source repository object with the specified id
 
     Args:
@@ -286,9 +285,8 @@ class SourceManager(object):
 
     return source
 
-  def _create_source_tree(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) \
-      -> source_tree.SourceTree:
+  def _create_source_tree(
+      self, source_id: proto_source.SourceRepository.SourceIdentity) -> source_tree.SourceTree:
     """Creates a source tree object from a SourceRepository.
 
     Args:
@@ -301,9 +299,8 @@ class SourceManager(object):
     repo = self.get_source_repository(source_id)
     return source_tree.SourceTree(repo)
 
-  def get_source_tree(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) \
-      -> source_tree.SourceTree:
+  def get_source_tree(
+      self, source_id: proto_source.SourceRepository.SourceIdentity) -> source_tree.SourceTree:
     """Returns the source tree object identified by source_id.
 
     Args:
@@ -323,9 +320,8 @@ class SourceManager(object):
 
     return self._source_tree[source_id]
 
-  def get_build_options(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) \
-      -> proto_source.BazelOption:
+  def get_build_options(
+      self, source_id: proto_source.SourceRepository.SourceIdentity) -> proto_source.BazelOption:
     """Determine whether build options are specified in the control object
     and return them
 
@@ -350,9 +346,7 @@ class SourceManager(object):
 
     return bazel_options
 
-  def have_build_options(self, \
-      source_id: proto_source.SourceRepository.SourceIdentity) \
-      -> bool:
+  def have_build_options(self, source_id: proto_source.SourceRepository.SourceIdentity) -> bool:
     """Determine whether build options are specified in the control object
        and return a boolean.  This is used to determine whether we build
        images or use the already available images

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -14,9 +14,9 @@ log = logging.getLogger(__name__)
    source code needed to build Envoy and NightHawk
 """
 _KNOWN_REPOSITORIES = {
-    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:   \
+    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:    \
       constants.ENVOY_GITHUB_REPO,
-    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:   \
+    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:    \
       constants.NIGHTHAWK_GITHUB_REPO
 }
 

--- a/salvo/src/lib/source_manager.py
+++ b/salvo/src/lib/source_manager.py
@@ -14,10 +14,8 @@ log = logging.getLogger(__name__)
    source code needed to build Envoy and NightHawk
 """
 _KNOWN_REPOSITORIES = {
-    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY:    \
-      constants.ENVOY_GITHUB_REPO,
-    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK:    \
-      constants.NIGHTHAWK_GITHUB_REPO
+    proto_source.SourceRepository.SourceIdentity.SRCID_ENVOY: constants.ENVOY_GITHUB_REPO,
+    proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK: constants.NIGHTHAWK_GITHUB_REPO
 }
 
 

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -59,7 +59,7 @@ class SourceTree(object):
     #       module will have one $HOME path defined and orchestrate sources
     #       to reduce/eliminate multiple copies of a source tree
 
-    home_dir = '' if not 'HOME' in os.environ else os.environ['HOME']
+    home_dir = '' if 'HOME' not in os.environ else os.environ['HOME']
     if not home_dir.startswith(constants.SALVO_TMP):
       home_dir = constants.SALVO_TMP
 

--- a/salvo/src/lib/test_cmd_exec.py
+++ b/salvo/src/lib/test_cmd_exec.py
@@ -64,8 +64,7 @@ def test_run_command_fail(mock_check_call):
     output = cmd_exec.run_command(cmd, cmd_parameters)
 
   assert not output
-  assert f"Command \'{cmd}\' returned non-zero exit status" in \
-    str(process_error.value)
+  assert f"Command \'{cmd}\' returned non-zero exit status" in str(process_error.value)
 
 
 @mock.patch('subprocess.check_call')
@@ -83,8 +82,7 @@ def test_run_check_command_fail(mock_check_call):
     output = cmd_exec.run_check_command(cmd, cmd_parameters)
 
   assert not output
-  assert f"Command \'{cmd}\' returned non-zero exit status" in \
-    str(process_error.value)
+  assert f"Command \'{cmd}\' returned non-zero exit status" in str(process_error.value)
 
 
 if __name__ == '__main__':

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -79,10 +79,8 @@ def _generate_default_benchmark_images(job_control):
   """
   image_config = job_control.images
   image_config.reuse_nh_images = True
-  image_config.nighthawk_benchmark_image = \
-    "envoyproxy/nighthawk-benchmark-dev:latest"
-  image_config.nighthawk_binary_image = \
-    "envoyproxy/nighthawk-dev:latest"
+  image_config.nighthawk_benchmark_image = "envoyproxy/nighthawk-benchmark-dev:latest"
+  image_config.nighthawk_binary_image = "envoyproxy/nighthawk-dev:latest"
 
   return image_config
 
@@ -222,8 +220,7 @@ def test_determine_envoy_hashes_from_source_pull_fail(mock_copy_source_directory
     hashes = manager.determine_envoy_hashes_from_source()
 
   assert not hashes
-  assert str(source_error.value) == \
-    "Unable to obtain the source to determine commit hashes"
+  assert str(source_error.value) == "Unable to obtain the source to determine commit hashes"
 
 
 def test_find_all_images_from_specified_tags():
@@ -262,8 +259,8 @@ def test_find_all_images_from_specified_tags_fail(mock_source_tree):
     hashes = manager.find_all_images_from_specified_tags()
 
   assert not hashes
-  assert str(source_error.value) == \
-    "No images are specified or able to be built from the control document"
+  assert str(
+      source_error.value) == "No images are specified or able to be built from the control document"
 
 
 def test_find_image_single():
@@ -320,8 +317,8 @@ def test_find_image_single_fail(mock_source_tree):
     hashes = manager.find_all_images_from_specified_tags()
 
   assert not hashes
-  assert str(source_error.value) == \
-    '"additional_envoy_image" cannot be set with "test_single_image" enabled'
+  assert str(source_error.value
+            ) == '"additional_envoy_image" cannot be set with "test_single_image" enabled'
 
 
 def test_find_all_images_from_specified_tags_build_envoy():
@@ -465,8 +462,8 @@ def test_find_all_images_from_specified_sources_single_fail(mock_copy_source_dir
   with pytest.raises(source_manager.SourceManagerError) as source_error:
     hashes = manager.find_all_images_from_specified_sources()
   assert not hashes
-  assert str(source_error.value) == \
-    '"additional_hashes" cannot be set with "test_single_commit" enabled'
+  assert str(
+      source_error.value) == '"additional_hashes" cannot be set with "test_single_commit" enabled'
 
 
 @mock.patch("src.lib.cmd_exec.run_command")

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -140,8 +140,7 @@ def test_get_origin_fail(mock_get_source_directory, mock_run_command):
     origin = source.get_origin()
 
   assert not origin
-  assert str(source_error.value) == \
-    "Unable to determine the origin url from /some_temp_directory"
+  assert str(source_error.value) == "Unable to determine the origin url from /some_temp_directory"
 
 
 def _generate_source_tree_from_origin(origin: str) -> source_tree.SourceTree:
@@ -369,8 +368,7 @@ def test_get_previous_commit_hash_fail(mock_check_output):
     hash_string = source.get_previous_commit_hash(commit_hash)
 
   assert not hash_string
-  assert str(source_error.value) == \
-    'No commit found prior to fake_commit_hash_1'
+  assert str(source_error.value) == 'No commit found prior to fake_commit_hash_1'
 
 
 @mock.patch('src.lib.cmd_exec.run_command')
@@ -520,8 +518,7 @@ def test_get_previous_tag_fail():
     previous_tag = source.get_previous_tag(current_tag)
 
   assert not previous_tag
-  assert str(source_error.value) == \
-    'The tag specified is not the expected format'
+  assert str(source_error.value) == 'The tag specified is not the expected format'
 
 
 def test_get_previous_n_tag():

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-MINIMUM_THRESHOLD=97.0
+MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.0}
 
 # This script executes all tests and then evaluates the code coverage
 # for Salvo.  All individual coverage files are merged to provide one

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -57,8 +57,9 @@ COVERAGE_PERCENTAGE=$(lcov --summary coverage/salvo.dat 2>&1 | grep lines | awk 
 
 if (( $(echo "${COVERAGE_PERCENTAGE} < ${MINIMUM_THRESHOLD}" | bc -l) ))
 then
-  echo "Test coverage percentage has dipped below ${MINIMUM_THRESHOLD}%"
+  echo "Test coverage percentage ${COVERAGE_PERCENTAGE}% has dipped below ${MINIMUM_THRESHOLD}%"
   exit 1
 fi
 
+echo "Tests coverage ${COVERAGE_PERCENTAGE}% was higher than or equest to ${MINIMUM_THRESHOLD}%"
 exit 0

--- a/salvo/tools/format_python_tools.sh
+++ b/salvo/tools/format_python_tools.sh
@@ -35,6 +35,7 @@ EXCLUDE="--exclude=benchmarks/tmp/*,.cache/*,*/venv/*,tools/format_python_tools.
 # F811 Redefinition of unused name from line n
 flake8 . ${EXCLUDE} --ignore=E114,E111,E501,F401,F811,E124,E125,E126,W504,D --count --show-source --statistics
 # D = Doc comment related checks (We check both p257 AND google conventions). 
-flake8 . ${EXCLUDE} --docstring-convention pep257 --select=D --count --show-source --statistics
-flake8 . ${EXCLUDE} --docstring-convention google --select=D --count --show-source --statistics
+# TODO(#137): Fix reported formatting errors and re-enable these checks.
+# flake8 . ${EXCLUDE} --docstring-convention pep257 --select=D --count --show-source --statistics
+# flake8 . ${EXCLUDE} --docstring-convention google --select=D --count --show-source --statistics
 

--- a/salvo/tools/format_python_tools.sh
+++ b/salvo/tools/format_python_tools.sh
@@ -28,11 +28,12 @@ EXCLUDE="--exclude=benchmarks/tmp/*,.cache/*,*/venv/*,tools/format_python_tools.
 # E124 Closing bracket does not match visual indentation
 # E125 Continuation line with same indent as next logical line
 # E126 Continuation line over-indented for hanging indent
+# W504 line break after binary operator
 
 # We ignore false positives because of what look like pytest peculiarities 
 # F401 Module imported but unused
 # F811 Redefinition of unused name from line n
-flake8 . ${EXCLUDE} --ignore=E114,E111,E501,F401,F811,E124,E125,E126,D --count --show-source --statistics
+flake8 . ${EXCLUDE} --ignore=E114,E111,E501,F401,F811,E124,E125,E126,W504,D --count --show-source --statistics
 # D = Doc comment related checks (We check both p257 AND google conventions). 
 flake8 . ${EXCLUDE} --docstring-convention pep257 --select=D --count --show-source --statistics
 flake8 . ${EXCLUDE} --docstring-convention google --select=D --count --show-source --statistics


### PR DESCRIPTION
This PR fixes #135:
- Adds `check-format`, `fix_format`(only for local execution) and `coverage` in ci/do_ci.sh and enables them in CircleCI.
- Improves the scripts to make the unit tests minimum threshold configurable, prints out more useful information.
- Fixes one flake8 formatting issues but disables two other flake8 checks, and will re-enable and fix them in another PR.