### PR TITLE
Add error trapping in Salvo test coverage checks

### DIFF
--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -36,6 +36,11 @@ CMD="${CMD} -o coverage/coverage.dat"
 
 # Extract all coverage data for salvo project files
 lcov -e coverage/coverage.dat -o coverage/salvo.dat '*/salvo/src/lib/*.py'
+if [ "$?" != "0" ]; then
+  echo "Failed to run test coverage checks."
+  exit 1
+fi
+
 
 # Redirect source file paths from the sandbox to the real source files.
 # Changes strings like this:
@@ -47,6 +52,10 @@ sed -e 's/SF.*\.runfiles\/salvo\/\(.*\)$/SF:\1/' -i coverage/salvo.dat
 # Generate HTML coverage report.
 mkdir -p coverage/html
 genhtml coverage/salvo.dat -o coverage/html
+if [ "$?" != "0" ]; then
+  echo "Failed to run test coverage checks."
+  exit 1
+fi
 echo "HTML coverage report generated, view by running:"
 echo "  (cd coverage/html && python3 -m http.server)"
 

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -36,11 +36,6 @@ CMD="${CMD} -o coverage/coverage.dat"
 
 # Extract all coverage data for salvo project files
 lcov -e coverage/coverage.dat -o coverage/salvo.dat '*/salvo/src/lib/*.py'
-if [ "$?" != "0" ]; then
-  echo "Failed to run test coverage checks."
-  exit 1
-fi
-
 
 # Redirect source file paths from the sandbox to the real source files.
 # Changes strings like this:
@@ -52,10 +47,6 @@ sed -e 's/SF.*\.runfiles\/salvo\/\(.*\)$/SF:\1/' -i coverage/salvo.dat
 # Generate HTML coverage report.
 mkdir -p coverage/html
 genhtml coverage/salvo.dat -o coverage/html
-if [ "$?" != "0" ]; then
-  echo "Failed to run test coverage checks."
-  exit 1
-fi
 echo "HTML coverage report generated, view by running:"
 echo "  (cd coverage/html && python3 -m http.server)"
 

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -7,7 +7,7 @@
 # Exit immediately if a command exits with a non-zero status.
 # pipefail indicates that the return value of a pipeline is the status
 # of the last command to exit with a non-zero status.
-set -exo pipefail
+set -eo pipefail
 
 # Adapted from https://github.com/bazelbuild/bazel/issues/10660
 GITHUB_WORKSPACE=${PWD}

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-
-MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.0}
-
 # This script executes all tests and then evaluates the code coverage
 # for Salvo.  All individual coverage files are merged to provide one
 # report for the entire codebase
 
+# Exit immediately if a command exits with a non-zero status.
+# pipefail indicates that the return value of a pipeline is the status
+# of the last command to exit with a non-zero status.
+set -exo pipefail
+
 # Adapted from https://github.com/bazelbuild/bazel/issues/10660
 GITHUB_WORKSPACE=${PWD}
+
+MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.0}
 
 cd ${GITHUB_WORKSPACE}
 if [ ! -d ${GITHUB_WORKSPACE}/coveragepy-lcov-support ]

--- a/salvo/tools/format_python_tools.sh
+++ b/salvo/tools/format_python_tools.sh
@@ -2,7 +2,10 @@
 
 # This script runs the style and formatting checks
 
-set -e
+# Exit immediately if a command exits with a non-zero status.
+# pipefail indicates that the return value of a pipeline is the status
+# of the last command to exit with a non-zero status.
+set -eo pipefail
 
 VENV_DIR="pyformat"
 SCRIPTPATH=$(realpath "$(dirname $0)")

--- a/salvo/tools/typecheck.sh
+++ b/salvo/tools/typecheck.sh
@@ -13,7 +13,7 @@ function die()
   exit 1
 }
 
-PYTYPE=$(which pytype)
+PYTYPE=$(which pytype) || true  # ignore exit code in this line
 if [ -z "${PYTYPE}"  -a -f ${HOME}/.local/bin/pytype ]
 then
   PYTYPE=${HOME}/.local/bin/pytype

--- a/salvo/tools/typecheck.sh
+++ b/salvo/tools/typecheck.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-set -x
-
+# Exit immediately if a command exits with a non-zero status.
+# pipefail indicates that the return value of a pipeline is the status
+# of the last command to exit with a non-zero status.
+set -exo pipefail
 
 function die()
 {


### PR DESCRIPTION
The Salvo test and coverage CI workflows show green though there are errors: 
https://app.circleci.com/pipelines/github/gyohuangxin/envoy-perf/13/workflows/e1eb2506-0730-4012-9616-1fbbc9140927/jobs/47?invite=true#step-102-1050
https://app.circleci.com/pipelines/github/gyohuangxin/envoy-perf/13/workflows/e1eb2506-0730-4012-9616-1fbbc9140927/jobs/48?invite=true#step-102-1022

This PR aims to add trapping at above errors and fix them.