### PR TITLE
add proxy for salvo dependency install doc

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -22,7 +22,11 @@ workflow documentation: [ENVOY_DEVELOP_WORKFLOW.md](./ENVOY_DEVELOP_WORKFLOW.md)
 
 The [`install_deps.sh`](./install_deps.sh) script can be used to install any dependencies required
 by Salvo.
-Dependencies installation needs root priviliges to perform. Using below command to make sure proxy(if any) works fine with root context.
+Dependencies installation needs root privileges to perform. Run the following command to install the required dependencies:
+```bash
+sudo ./install_deps.sh
+```
+If you are using a proxy server, run the following command to download any packages via a proxy server:
 ```bash
 sudo http_proxy="example.com:port" https_proxy="example.com:port"  ./install_deps.sh
 ```

--- a/salvo/README.md
+++ b/salvo/README.md
@@ -22,6 +22,10 @@ workflow documentation: [ENVOY_DEVELOP_WORKFLOW.md](./ENVOY_DEVELOP_WORKFLOW.md)
 
 The [`install_deps.sh`](./install_deps.sh) script can be used to install any dependencies required
 by Salvo.
+Dependencies installation needs root priviliges to perform. Using below command to make sure proxy(if any) works fine with root context.
+```bash
+sudo http_proxy="example.com:port" https_proxy="example.com:port" ; ./install_deps.sh
+```
 
 ## Building Salvo
 

--- a/salvo/README.md
+++ b/salvo/README.md
@@ -24,7 +24,7 @@ The [`install_deps.sh`](./install_deps.sh) script can be used to install any dep
 by Salvo.
 Dependencies installation needs root priviliges to perform. Using below command to make sure proxy(if any) works fine with root context.
 ```bash
-sudo http_proxy="example.com:port" https_proxy="example.com:port" ; ./install_deps.sh
+sudo http_proxy="example.com:port" https_proxy="example.com:port"  ./install_deps.sh
 ```
 
 ## Building Salvo


### PR DESCRIPTION
Executing install_deps.sh with sudo may lost proxy environment and cause network fail. Add doc example to avoid that.