### PR TITLE
Fix log duplication

### DIFF
--- a/salvo/src/lib/builder/base_builder.py
+++ b/salvo/src/lib/builder/base_builder.py
@@ -71,7 +71,7 @@ class BaseBuilder():
 
     cmd_params = cmd_exec.CommandParameters(cwd=self._build_dir)
     cmd = "bazel clean"
-    output = cmd_exec.run_command(cmd, cmd_params)
+    output = cmd_exec.run_command(cmd, cmd_params, False)
     log.debug(f"Clean output: {output}")
 
   def _generate_bazel_options(self, source_id: proto_source.SourceRepository.SourceIdentity) -> str:

--- a/salvo/src/lib/builder/nighthawk_builder.py
+++ b/salvo/src/lib/builder/nighthawk_builder.py
@@ -30,7 +30,7 @@ def _execute_docker_image_script(script: str, build_dir: str) -> None:
     build_dir: The nighthawk source location
   """
   cmd_params = cmd_exec.CommandParameters(cwd=build_dir)
-  output = cmd_exec.run_command(script, cmd_params)
+  output = cmd_exec.run_command(script, cmd_params, False)
   log.debug(f"NightHawk Docker image output for {script}: {output}")
 
 
@@ -89,7 +89,7 @@ class NightHawkBuilder(base_builder.BaseBuilder):
     bazel_options = self._generate_bazel_options(
         proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK)
     cmd = "bazel build {bazel_options} //benchmarks:benchmarks".format(bazel_options=bazel_options)
-    output = cmd_exec.run_command(cmd, cmd_params)
+    output = cmd_exec.run_command(cmd, cmd_params, False)
 
     log.debug(f"Nighthawk build output: {output}")
 
@@ -104,7 +104,7 @@ class NightHawkBuilder(base_builder.BaseBuilder):
     bazel_options = self._generate_bazel_options(
         proto_source.SourceRepository.SourceIdentity.SRCID_NIGHTHAWK)
     cmd = "bazel build {bazel_options} //:nighthawk".format(bazel_options=bazel_options)
-    output = cmd_exec.run_command(cmd, cmd_params)
+    output = cmd_exec.run_command(cmd, cmd_params, False)
 
     log.debug(f"Nighthawk build output: {output}")
 

--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -8,12 +8,14 @@ from src.lib.builder import envoy_builder
 from src.lib import (constants, source_tree, source_manager)
 
 
-def _check_call_side_effect(args, parameters):
+def _check_call_side_effect(args, parameters, debug=False):
   """Examine the incoming arguments for command execution and return the expected or unexpected output.
 
   Args:
     args: The arguments supplied to the mocked function
     parameters: The CommandParameters passed to the cmd_exec method
+    debug: Argument to control default log output print behavior.
+
   Return:
     usually this returns a string containing the command output.  In
       some cases we may raise an exception.

--- a/salvo/src/lib/builder/test_nighthawk_builder.py
+++ b/salvo/src/lib/builder/test_nighthawk_builder.py
@@ -46,7 +46,7 @@ def test_prepare_nighthawk_source(mock_pull, mock_copy_source, mock_get_source_d
     builder.prepare_nighthawk_source()
 
   params = cmd_exec.CommandParameters(cwd='/tmp/nighthawk_source_dir')
-  mock_cmd.assert_called_once_with(_BAZEL_CLEAN_CMD, params)
+  mock_cmd.assert_called_once_with(_BAZEL_CLEAN_CMD, params, False)
   mock_pull.assert_called_once()
   mock_copy_source.assert_called_once()
 
@@ -60,8 +60,8 @@ def test_build_nighthawk_benchmarks(mock_pull, mock_copy_source, mock_run_comman
   mock_copy_source.return_value = None
   mock_run_command.side_effect = ['bazel clean output ...', 'bazel build output ...']
   calls = [
-      mock.call(_BAZEL_CLEAN_CMD, mock.ANY),
-      mock.call("bazel build --jobs 4 -c opt //benchmarks:benchmarks", mock.ANY)
+      mock.call(_BAZEL_CLEAN_CMD, mock.ANY, mock.ANY),
+      mock.call("bazel build --jobs 4 -c opt //benchmarks:benchmarks", mock.ANY, mock.ANY)
   ]
 
   manager = _generate_default_source_manager()
@@ -86,8 +86,8 @@ def test_build_nighthawk_binaries(mock_pull, mock_copy_source, mock_run_command)
   mock_copy_source.return_value = None
   mock_run_command.side_effect = ['bazel clean output', 'bazel nighthawk build output ...']
   calls = [
-      mock.call(_BAZEL_CLEAN_CMD, mock.ANY),
-      mock.call("bazel build --jobs 4 -c dbg //:nighthawk", mock.ANY)
+      mock.call(_BAZEL_CLEAN_CMD, mock.ANY, mock.ANY),
+      mock.call("bazel build --jobs 4 -c dbg //:nighthawk", mock.ANY, mock.ANY)
   ]
   manager = _generate_default_source_manager()
 
@@ -112,9 +112,9 @@ def test_build_nighthawk_benchmark_image(mock_pull, mock_run_command):
       'bazel benchmark image build output ...'
   ]
   calls = [
-      mock.call(_BAZEL_CLEAN_CMD, mock.ANY),
-      mock.call("bazel build -c opt //benchmarks:benchmarks", mock.ANY),
-      mock.call(constants.NH_BENCHMARK_IMAGE_SCRIPT, mock.ANY)
+      mock.call(_BAZEL_CLEAN_CMD, mock.ANY, mock.ANY),
+      mock.call("bazel build -c opt //benchmarks:benchmarks", mock.ANY, mock.ANY),
+      mock.call(constants.NH_BENCHMARK_IMAGE_SCRIPT, mock.ANY, mock.ANY)
   ]
 
   manager = _generate_default_source_manager()
@@ -135,9 +135,9 @@ def test_build_nighthawk_binary_image(mock_pull, mock_run_command):
       'bazel benchmark image build output ...'
   ]
   calls = [
-      mock.call(_BAZEL_CLEAN_CMD, mock.ANY),
-      mock.call("bazel build -c opt //:nighthawk", mock.ANY),
-      mock.call(constants.NH_BINARY_IMAGE_SCRIPT, mock.ANY)
+      mock.call(_BAZEL_CLEAN_CMD, mock.ANY, mock.ANY),
+      mock.call("bazel build -c opt //:nighthawk", mock.ANY, mock.ANY),
+      mock.call(constants.NH_BINARY_IMAGE_SCRIPT, mock.ANY, mock.ANY)
   ]
 
   manager = _generate_default_source_manager()

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -17,7 +17,7 @@ CommandParameters = typing.NamedTuple(
     ])
 
 
-def run_command(cmd: str, parameters: CommandParameters) -> str:
+def run_command(cmd: str, parameters: CommandParameters, debug=True) -> str:
   """Run the specified command returning its output to the caller.
 
   Args:
@@ -61,8 +61,8 @@ def run_command(cmd: str, parameters: CommandParameters) -> str:
 
     if isinstance(output, bytes):
       output = output.decode('utf-8').strip()
-
-    log.debug(f"Returning output: [{output}]")
+    if debug:
+      log.debug(f"Returning output: [{output}]")
 
   return output
 

--- a/salvo/src/lib/cmd_exec.py
+++ b/salvo/src/lib/cmd_exec.py
@@ -27,6 +27,7 @@ def run_command(cmd: str, parameters: CommandParameters, debug=True) -> str:
         where the command is to be executed.  Other parameters supported
         by the subprocess module will be added as they become necessary for
         execution.
+      debug: Argument to control default log output print behavior.
 
   Returns:
       The output produced by the command


### PR DESCRIPTION
Add argument to control print behavior of run_command function.
Disable it when unnecessary to print log.


Signed-off-by: xu1zhou <yizhou.xu@intel.com>