### PR TITLE
Add annotation to switch to root diretory when building Salvo by docker.

### DIFF
--- a/salvo/README.md
+++ b/salvo/README.md
@@ -46,6 +46,7 @@ export  ENVOY_DOCKER_BUILD_DIR=/tmp/salvo-docker-build
 export  BUILD_DIR_MOUNT_DEST=/tmp/salvo-docker-build
 export  SOURCE_DIR_MOUNT_DEST=path_of_your_envoy-perf
 
+# Switch to root directory of envoy-perf
 ci/run_envoy_docker.sh 'ci/do_ci.sh build'
 ```
 


### PR DESCRIPTION
All commands in Salvo's doc are based on envoy-perf/salvo directory, so it will fail to execute `ci/run_envoy_docker.sh 'ci/do_ci.sh build'`. 

I add a annotation reminding to switch to root directory when build Salvo by docker.