### PR TITLE
Improvements to line coverage analysis.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -60,6 +60,7 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
     - task: PublishPipelineArtifact@1
+      displayName: 'Publish the line coverage report'
       inputs:
         targetPath: $(System.DefaultWorkingDirectory)/salvo/coverage/html.zip
         artifactName: CoverageReport

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,47 +4,46 @@ trigger:
     - "main"
 
 stages:
-#- stage: check
-#  dependsOn: []
-#  pool: "x64-large"
-#  jobs:
-#  - job: build_and_format
-#    displayName: "do_ci.sh"
-#    dependsOn: []
-#    strategy:
-#      maxParallel: 2
-#      matrix:
-#        build:
-#          CI_TARGET: "build"
-#        format:
-#          CI_TARGET: "check_format"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
-#
-#- stage: test
-#  dependsOn: ["check"]
-#  pool: "x64-large"
-#  jobs:
-#  - job: test
-#    displayName: "do_ci.sh"
-#    dependsOn: []
-#    strategy:
-#      maxParallel: 1
-#      matrix:
-#        test:
-#          CI_TARGET: "test"
-#    timeoutInMinutes: 120
-#    steps:
-#    - template: bazel.yml
-#      parameters:
-#        ciTarget: $(CI_TARGET)
+- stage: check
+  dependsOn: []
+  pool: "x64-large"
+  jobs:
+  - job: build_and_format
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 2
+      matrix:
+        build:
+          CI_TARGET: "build"
+        format:
+          CI_TARGET: "check_format"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
+
+- stage: test
+  dependsOn: ["check"]
+  pool: "x64-large"
+  jobs:
+  - job: test
+    displayName: "do_ci.sh"
+    dependsOn: []
+    strategy:
+      maxParallel: 1
+      matrix:
+        test:
+          CI_TARGET: "test"
+    timeoutInMinutes: 120
+    steps:
+    - template: bazel.yml
+      parameters:
+        ciTarget: $(CI_TARGET)
 
 - stage: coverage
-  #dependsOn: ["test"]
-  dependsOn: []
+  dependsOn: ["test"]
   pool: "x64-large"
   jobs:
   - job: coverage

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -47,13 +47,13 @@ stages:
   dependsOn: []
   pool: "x64-large"
   jobs:
-  - job: test
+  - job: coverage
     displayName: "do_ci.sh"
     dependsOn: []
     strategy:
       maxParallel: 1
       matrix:
-        test:
+        coverage:
           CI_TARGET: "coverage"
     timeoutInMinutes: 120
     steps:

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -4,46 +4,47 @@ trigger:
     - "main"
 
 stages:
-- stage: check
-  dependsOn: []
-  pool: "x64-large"
-  jobs:
-  - job: build_and_format
-    displayName: "do_ci.sh"
-    dependsOn: []
-    strategy:
-      maxParallel: 2
-      matrix:
-        build:
-          CI_TARGET: "build"
-        format:
-          CI_TARGET: "check_format"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-
-- stage: test
-  dependsOn: ["check"]
-  pool: "x64-large"
-  jobs:
-  - job: test
-    displayName: "do_ci.sh"
-    dependsOn: []
-    strategy:
-      maxParallel: 1
-      matrix:
-        test:
-          CI_TARGET: "test"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
+#- stage: check
+#  dependsOn: []
+#  pool: "x64-large"
+#  jobs:
+#  - job: build_and_format
+#    displayName: "do_ci.sh"
+#    dependsOn: []
+#    strategy:
+#      maxParallel: 2
+#      matrix:
+#        build:
+#          CI_TARGET: "build"
+#        format:
+#          CI_TARGET: "check_format"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#
+#- stage: test
+#  dependsOn: ["check"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: test
+#    displayName: "do_ci.sh"
+#    dependsOn: []
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        test:
+#          CI_TARGET: "test"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
 
 - stage: coverage
-  dependsOn: ["test"]
+  #dependsOn: ["test"]
+  dependsOn: []
   pool: "x64-large"
   jobs:
   - job: test
@@ -59,3 +60,7 @@ stages:
     - template: bazel.yml
       parameters:
         ciTarget: $(CI_TARGET)
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: $(System.DefaultWorkingDirectory)/salvo/coverage/html.zip
+        artifactName: CoverageReport

--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -25,8 +25,8 @@ fi
   python3-pytest
 
 
-#pip3 install --upgrade --user pip
-#pip3 install --upgrade --user setuptools
-#pip3 install --user -r requirements.txt
+pip3 install --upgrade --user pip
+pip3 install --upgrade --user setuptools
+pip3 install --user -r requirements.txt
 
-#touch ${HOME}/.salvo_deps_installed
+touch ${HOME}/.salvo_deps_installed

--- a/salvo/install_deps.sh
+++ b/salvo/install_deps.sh
@@ -16,15 +16,17 @@ fi
 
 /usr/bin/apt update
 /usr/bin/apt -y install \
-  docker.io \
-  python3-pytest \
-  python3-docker \
+  docker.io
+/usr/bin/apt -y install \
+  lcov \
   openjdk-11-jdk \
-  python3-pip
+  python3-docker \
+  python3-pip \
+  python3-pytest
 
 
-pip3 install --upgrade --user pip
-pip3 install --upgrade --user setuptools
-pip3 install --user -r requirements.txt
+#pip3 install --upgrade --user pip
+#pip3 install --upgrade --user setuptools
+#pip3 install --user -r requirements.txt
 
-touch ${HOME}/.salvo_deps_installed
+#touch ${HOME}/.salvo_deps_installed

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -64,9 +64,16 @@ mkdir -p coverage/html
 genhtml coverage/salvo.dat -o coverage/html
 zip -r coverage/html.zip coverage/html/
 
-echo "HTML coverage report generated, view by running:"
-echo "  (cd salvo/coverage/html && python3 -m http.server)"
-echo "Or download the zip file from salvo/coverage/html.zip"
+echo <<EOF
+HTML coverage report generated.
+
+If you are running the CI script locally, you can view it by starting a local
+HTTP server, e.g.:
+  (cd salvo/coverage/html && python3 -m http.server)
+
+If the coverage runs in Azure Pipelines, the pipeline publishes a zipped
+coverage report as a pipeline artifact.
+EOF
 
 # Examine the coverage summary and extract the overall coverage percentage.
 # If the reported threshold drops below the specified threshold, then we

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # Adapted from https://github.com/bazelbuild/bazel/issues/10660
 GITHUB_WORKSPACE=${PWD}
 
-MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.0}
+MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.5}
 
 cd ${GITHUB_WORKSPACE}
 if [ ! -d ${GITHUB_WORKSPACE}/coveragepy-lcov-support ]
@@ -20,10 +20,11 @@ then
   curl -L https://github.com/ulfjack/coveragepy/archive/lcov-support.tar.gz | tar xz
 fi
 
-bazel coverage -t- --instrument_test_targets \
-	--test_output=errors \
+bazel coverage -t- \
+  --instrument_test_targets \
+  --test_output=errors \
   --linkopt=--coverage \
-	--test_env=PYTHON_COVERAGE=${GITHUB_WORKSPACE}/coveragepy-lcov-support/__main__.py \
+  --test_env=PYTHON_COVERAGE=${GITHUB_WORKSPACE}/coveragepy-lcov-support/__main__.py \
   --java_runtime_version=remotejdk_11 \
   //...
 
@@ -38,8 +39,18 @@ mkdir -p coverage
 CMD="${CMD} -o coverage/coverage.dat"
 (${CMD})
 
+# Remove files we can't calculate coverage on:
+#   - auto-generated protocol buffer libraries.
+lcov \
+  --remove coverage/coverage.dat \
+  -o coverage/coverage_filtered.dat \
+  '*_pb2.py'
+
 # Extract all coverage data for salvo project files
-lcov -e coverage/coverage.dat -o coverage/salvo.dat '*/salvo/src/lib/*.py'
+lcov \
+  -e coverage/coverage_filtered.dat \
+  -o coverage/salvo.dat \
+  '*/*runfiles/salvo/*'
 
 # Redirect source file paths from the sandbox to the real source files.
 # Changes strings like this:
@@ -51,8 +62,11 @@ sed -e 's/SF.*\.runfiles\/salvo\/\(.*\)$/SF:\1/' -i coverage/salvo.dat
 # Generate HTML coverage report.
 mkdir -p coverage/html
 genhtml coverage/salvo.dat -o coverage/html
+zip -r coverage/html.zip coverage/html/
+
 echo "HTML coverage report generated, view by running:"
-echo "  (cd coverage/html && python3 -m http.server)"
+echo "  (cd salvo/coverage/html && python3 -m http.server)"
+echo "Or download the zip file from salvo/coverage/html.zip"
 
 # Examine the coverage summary and extract the overall coverage percentage.
 # If the reported threshold drops below the specified threshold, then we
@@ -66,5 +80,5 @@ then
   exit 1
 fi
 
-echo "Tests coverage ${COVERAGE_PERCENTAGE}% was higher than or equest to ${MINIMUM_THRESHOLD}%"
+echo "Tests coverage ${COVERAGE_PERCENTAGE}% was higher than or equal to ${MINIMUM_THRESHOLD}%"
 exit 0


### PR DESCRIPTION
- calculate coverage for all directories, not just `src/lib`, this will be future proof when we add more code directories.
- increase the coverage threshold according to current level.
- split `apt` execution to two commands, installing `docker.io` in a separate execution. This allows installation of the remaining packages to continue on machines that cannot install `docker.io`.
- publish the coverage html report as an artifact in the CI pipeline.
- Rename coverage CI steps from `test` to `coverage`.
- fix a typo and reformat the script.