### PR TITLE
Bump yapf from 0.30.0 to 0.32.0 in /salvo

### DIFF
--- a/salvo/src/lib/builder/test_envoy_builder.py
+++ b/salvo/src/lib/builder/test_envoy_builder.py
@@ -26,7 +26,8 @@ def _check_call_side_effect(args, parameters):
     return "building..."
   elif args == "bazel build -c opt external:su-exec":
     return "building su-exec ..."
-  elif args == ("cp -fv bazel-bin/source/exe/envoy-static " "build_release_stripped/envoy"):
+  elif args == ("cp -fv bazel-bin/source/exe/envoy-static "
+                "build_release_stripped/envoy"):
     return "copied..."
   elif args == ("cp -fv bazel-bin/external/com_github_ncopa_suexec/su-exec "
                 "build_release/su-exec"):

--- a/salvo/src/lib/run_benchmark.py
+++ b/salvo/src/lib/run_benchmark.py
@@ -383,5 +383,6 @@ class BenchmarkRunner(object):
 
     bar = '=' * 20
     for benchmark in self._test:
-      log.info(f"{bar} Running {benchmark.get_name()} for " f"{benchmark.get_image()} {bar}")
+      log.info(f"{bar} Running {benchmark.get_name()} for "
+               f"{benchmark.get_image()} {bar}")
       benchmark.execute_benchmark()

--- a/salvo/src/lib/source_tree.py
+++ b/salvo/src/lib/source_tree.py
@@ -189,7 +189,8 @@ class SourceTree(object):
     if os.path.exists(output_directory):
       file_ops.delete_directory(output_directory)
 
-    log.debug(f"Copying tree from {self._source_repo.source_path} " f"to {output_directory}")
+    log.debug(f"Copying tree from {self._source_repo.source_path} "
+              f"to {output_directory}")
     ignore_bazel = shutil.ignore_patterns('bazel-*')
     shutil.copytree(self._source_repo.source_path,
                     output_directory,
@@ -210,7 +211,8 @@ class SourceTree(object):
     self._validate()
 
     source_name = proto_source.SourceRepository.SourceIdentity.Name(self._source_repo.identity)
-    log.debug(f"Pulling [{source_name}] from origin: " f"[{self._source_repo.source_url}]")
+    log.debug(f"Pulling [{source_name}] from origin: "
+              f"[{self._source_repo.source_url}]")
 
     if not self._source_repo.source_url:
       log.debug("No url specified for source. Cannot pull.")
@@ -320,7 +322,8 @@ class SourceTree(object):
     # lines that may have trailed the original git output
     for commit_hash in hash_list.split('\n')[::-1]:
       if commit_hash:
-        log.debug(f"Returning {commit_hash} as the previous commit to " f"{current_commit}")
+        log.debug(f"Returning {commit_hash} as the previous commit to "
+                  f"{current_commit}")
         return commit_hash
 
     raise SourceTreeError(f"No commit found prior to {current_commit}")

--- a/salvo/src/lib/test_run_benchmark.py
+++ b/salvo/src/lib/test_run_benchmark.py
@@ -10,6 +10,7 @@ from src.lib.benchmark import (scavenging_benchmark, fully_dockerized_benchmark 
                                binary_benchmark as binbench)
 
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
 
 _BUILD_ENVOY_IMAGE_FROM_SOURCE = \

--- a/salvo/src/lib/test_source_manager.py
+++ b/salvo/src/lib/test_source_manager.py
@@ -50,7 +50,8 @@ def _run_command_side_effect(*args):
   elif args[0] == ("git rev-list --no-merges "
                    "--committer=\'GitHub <noreply@github.com>\' "
                    "--max-count=2 expected_baseline_hash"):
-    return ('expected_baseline_hash\n' 'expected_previous_commit_hash')
+    return ('expected_baseline_hash\n'
+            'expected_previous_commit_hash')
 
   elif args[0] == 'git clone git@github.com:username/reponame.git .':
     return 'Cloning into \'.\''

--- a/salvo/src/lib/test_source_tree.py
+++ b/salvo/src/lib/test_source_tree.py
@@ -177,7 +177,8 @@ def mock_run_command_side_effect(*function_args):
   elif function_args[0] == ("git rev-list --no-merges "
                             "--committer=\'GitHub <noreply@github.com>\' "
                             "--max-count=2 fake_commit_hash_1"):
-    return ("fake_commit_hash_1\n" "fake_commit_hash_2\n")
+    return ("fake_commit_hash_1\n"
+            "fake_commit_hash_2\n")
 
   elif function_args[0] == ("git rev-list --no-merges "
                             "--committer=\'GitHub <noreply@github.com>\' "

--- a/salvo/tools/coverage.sh
+++ b/salvo/tools/coverage.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 # Adapted from https://github.com/bazelbuild/bazel/issues/10660
 GITHUB_WORKSPACE=${PWD}
 
-MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.5}
+MINIMUM_THRESHOLD=${MINIMUM_THRESHOLD:=97.4}
 
 cd ${GITHUB_WORKSPACE}
 if [ ! -d ${GITHUB_WORKSPACE}/coveragepy-lcov-support ]

--- a/salvo/tools/format_python_tools.sh
+++ b/salvo/tools/format_python_tools.sh
@@ -21,7 +21,7 @@ python format_python_tools.py $1
 
 echo "Running Python3 flake8 check..."
 cd ..
-EXCLUDE="--exclude=benchmarks/tmp/*,.cache/*,*/venv/*,tools/format_python_tools.py,tools/gen_compilation_database.py,bazel-*"
+EXCLUDE="--exclude=benchmarks/tmp/*,.cache/*,*/venv/*,tools/format_python_tools.py,tools/gen_compilation_database.py,bazel-*,coveragepy-lcov-support/"
 
 
 # Because of conflict with the automatic fix format script, we ignore: 

--- a/salvo/tools/requirements.txt
+++ b/salvo/tools/requirements.txt
@@ -1,3 +1,3 @@
 flake8==5.0.4
-yapf==0.30.0
+yapf==0.32.0
 flake8-docstrings==1.6.0


### PR DESCRIPTION
Also:
- reformatted files accordingly. All formatting changes were done by running `./ci/do_ci.sh fix_format`.
- exclude local directory `coveragepy-lcov-support` from flake8 checks.
- adjusting coverage after the formatting changes.

Replaces https://github.com/envoyproxy/envoy-perf/pull/174.

Signed-off-by: Jakub Sobon <mumak@google.com>