### PR TITLE
Disable coverage report until it is fixed.

### DIFF
--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -42,26 +42,27 @@ stages:
       parameters:
         ciTarget: $(CI_TARGET)
 
-- stage: coverage
-  dependsOn: ["test"]
-  pool: "x64-large"
-  jobs:
-  - job: coverage
-    displayName: "do_ci.sh"
-    dependsOn: []
-    strategy:
-      maxParallel: 1
-      matrix:
-        coverage:
-          CI_TARGET: "coverage"
-    timeoutInMinutes: 120
-    steps:
-    - template: bazel.yml
-      parameters:
-        ciTarget: $(CI_TARGET)
-    - task: PublishPipelineArtifact@1
-      condition: always()
-      displayName: 'Publish the line coverage report'
-      inputs:
-        targetPath: $(System.DefaultWorkingDirectory)/salvo/coverage/html.zip
-        artifactName: CoverageReport-$(System.JobAttempt)
+# TODO(#187): Re-enable once coverage reporting is fixed.
+#- stage: coverage
+#  dependsOn: ["test"]
+#  pool: "x64-large"
+#  jobs:
+#  - job: coverage
+#    displayName: "do_ci.sh"
+#    dependsOn: []
+#    strategy:
+#      maxParallel: 1
+#      matrix:
+#        coverage:
+#          CI_TARGET: "coverage"
+#    timeoutInMinutes: 120
+#    steps:
+#    - template: bazel.yml
+#      parameters:
+#        ciTarget: $(CI_TARGET)
+#    - task: PublishPipelineArtifact@1
+#      condition: always()
+#      displayName: 'Publish the line coverage report'
+#      inputs:
+#        targetPath: $(System.DefaultWorkingDirectory)/salvo/coverage/html.zip
+#        artifactName: CoverageReport-$(System.JobAttempt)

--- a/.azure-pipelines/pipelines.yml
+++ b/.azure-pipelines/pipelines.yml
@@ -64,4 +64,4 @@ stages:
       displayName: 'Publish the line coverage report'
       inputs:
         targetPath: $(System.DefaultWorkingDirectory)/salvo/coverage/html.zip
-        artifactName: CoverageReport
+        artifactName: CoverageReport-$(System.JobAttempt)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -31,8 +31,6 @@ function test_salvo() {
 
   setup_salvo_venv
   bazel test //...
-  # TODO(#187): Re-enable once coverage reporting is fixed.
-  # tools/coverage.sh
 
   popd
 }

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -30,7 +30,9 @@ function test_salvo() {
   pushd salvo
 
   setup_salvo_venv
-  tools/coverage.sh
+  bazel test //...
+  # TODO(#187): Re-enable once coverage reporting is fixed.
+  # tools/coverage.sh
 
   popd
 }


### PR DESCRIPTION
Works on #187 

Also include the `System.JobAttempt` in the artifact name to ensure unique artifact names for each retry. This was tested in the Nighthawk repository and will be useful once we re-enable the coverage report.

Signed-off-by: Jakub Sobon <mumak@google.com>