### PR TITLE
Packer scripts that build AMI for Salvo's component VMs.

### DIFF
--- a/salvo-remote/packer-ami-build/README.md
+++ b/salvo-remote/packer-ami-build/README.md
@@ -1,0 +1,7 @@
+# Packer AMI Builds
+
+This is a series of [Packer](https://www.packer.io/) scripts to build AMIs
+that will be launched on AWS.
+
+- `salvo-component-vm-x64.pkr.hcl` is an AMI that runs a component (e.g.
+  Nighthawk, or the Envoy) in a Salvo test.

--- a/salvo-remote/packer-ami-build/salvo-component-vm-x64.pkr.hcl
+++ b/salvo-remote/packer-ami-build/salvo-component-vm-x64.pkr.hcl
@@ -69,6 +69,6 @@ build {
       "AZURE_DEVOPS_EXT_PAT" : "${var.azure_devops_ext_pat}"
       "AZP_BUILD_ID" : "${var.azp_build_id}"
     }
-    execute_command = "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
+    execute_command = "{{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
   }
 }

--- a/salvo-remote/packer-ami-build/salvo-component-vm-x64.pkr.hcl
+++ b/salvo-remote/packer-ami-build/salvo-component-vm-x64.pkr.hcl
@@ -1,0 +1,74 @@
+# Defines a Packer template that builds an AMI image of a Salvo test component
+# VM.
+
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.1"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "azure_devops_ext_pat" {
+  type    = string
+  default = "default_azure_devops_ext_pat_is_not_valid"
+}
+
+variable "azp_build_id" {
+  type    = string
+  default = "default_build_id_is_not_valid"
+}
+
+# See https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs.
+source "amazon-ebs" "salvo-component-vm-x64" {
+  ami_name                    = "salvo-component-vm-x64-${var.azp_build_id}-{{timestamp}}"
+  instance_type               = "m6i.large"
+  region                      = "us-east-2"
+  vpc_id                      = "vpc-09623ca46adcf44aa" # salvo-vpc
+  associate_public_ip_address = true
+  subnet_id                   = "subnet-06a291300c69ce70c" # salvo-packer-subnet
+
+  source_ami_filter {
+    filters = {
+      # Found with:
+      # aws ec2 describe-images --owners 'aws-marketplace' --output json --region us-east-2 --filters "Name=product-code,Values=4s6b2r2vfe46kyul508kf459f"
+      name                = "ubuntu-minimal/images/hvm-ssd/ubuntu-jammy-22.04-amd64-minimal-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["679593333241"]
+  }
+  encrypt_boot = true
+  ssh_username = "ubuntu"
+
+  run_tags = {
+    "Project" : "Packer"
+  }
+  run_volume_tags = {
+    "Project" : "Packer"
+  }
+  tags = {
+    "Project" : "Salvo",
+    "AmiType" : "salvo-component-vm-x64"
+    "AzpBuildId" : "${var.azp_build_id}"
+  }
+}
+
+build {
+  name = "salvo-component-vm-x64"
+  sources = [
+    "source.amazon-ebs.salvo-component-vm-x64"
+  ]
+
+  # See https://developer.hashicorp.com/packer/docs/provisioners/shell.
+  provisioner "shell" {
+    script = "salvo-component-vm.sh"
+    env = {
+      "AZURE_DEVOPS_EXT_PAT" : "${var.azure_devops_ext_pat}"
+      "AZP_BUILD_ID" : "${var.azp_build_id}"
+    }
+    execute_command = "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
+  }
+}

--- a/salvo-remote/packer-ami-build/salvo-component-vm.sh
+++ b/salvo-remote/packer-ami-build/salvo-component-vm.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+# Upgrade installed packages.
+sudo apt-get -qq update
+sudo apt-get -qq upgrade -y
+
+# Workaround for AzureCLI that requires the older version of libssl.
+# The version of .NET Core used by the AzureCLI is not capable of working with
+# libssl.so.1.1 yet. Forcing libssl.so.1.0.
+# See https://github.com/Azure/azure-cli/issues/22230.
+LIBSSL1_DIR="/tmp/libssl1"
+wget -q -r -l1 -np \
+  -P "${LIBSSL1_DIR}" \
+  -A 'libssl1.0.0*ubuntu*amd64.deb' \
+  "http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/"
+LIBSSL1_PACKAGE=`find "${LIBSSL1_DIR}" -type f -name \*.deb | sort | head -n 1`
+sudo dpkg -i "${LIBSSL1_PACKAGE}"
+sudo sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+
+# Setup a local user to run Salvo components.
+COMPONENT_DIR="/salvo/components"
+sudo groupadd salvo
+sudo useradd -ms /bin/bash -g salvo salvo
+sudo mkdir -p "${COMPONENT_DIR}"
+
+# Install AzureCLI.
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+az extension add --name azure-devops
+az devops configure --defaults organization=https://dev.azure.com/cncf project=envoy
+
+# Download the components built by the Salvo pipeline.
+# Depends on AZURE_DEVOPS_EXT_PAT= being set to a valid AZP token.
+az pipelines runs artifact download \
+  --artifact-name "Envoy server" \
+  --run-id "${AZP_BUILD_ID}" \
+  --path "${COMPONENT_DIR}"
+az pipelines runs artifact download \
+  --artifact-name "Nighthawk client" \
+  --run-id "${AZP_BUILD_ID}" \
+  --path "${COMPONENT_DIR}"
+az pipelines runs artifact download \
+  --artifact-name "Nighthawk test server" \
+  --run-id "${AZP_BUILD_ID}" \
+  --path "${COMPONENT_DIR}"
+
+# Unpack the components and make them executable.
+sudo tar -xzf /salvo/components/envoy_binary.tar.gz -C /salvo/components/
+sudo ln -s /salvo/components/build_envoy_release/envoy /salvo/components/envoy
+sudo ln -s /salvo/components/build_envoy_release_stripped/envoy /salvo/components/envoy_stripped
+sudo chown -R salvo:salvo /salvo/
+sudo chmod 0755 /salvo/components/nighthawk*
+
+# Undo the libssl workaround done for AzureCLI.
+sudo sed -i 's/#openssl_conf = openssl_init/openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+sudo dpkg -r $(dpkg -f "${LIBSSL1_PACKAGE}" Package)
+

--- a/salvo-remote/packer-ami-build/salvo-component-vm.sh
+++ b/salvo-remote/packer-ami-build/salvo-component-vm.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Upgrade installed packages.
-sudo apt-get -qq update
-sudo apt-get -qq upgrade -y
+apt-get -qq update
+apt-get -qq upgrade -y
 
 # Workaround for AzureCLI that requires the older version of libssl.
 # The version of .NET Core used by the AzureCLI is not capable of working with
@@ -16,17 +16,17 @@ wget -q -r -l1 -np \
   -A 'libssl1.0.0*ubuntu*amd64.deb' \
   "http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/"
 LIBSSL1_PACKAGE=`find "${LIBSSL1_DIR}" -type f -name \*.deb | sort | head -n 1`
-sudo dpkg -i "${LIBSSL1_PACKAGE}"
-sudo sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+dpkg -i "${LIBSSL1_PACKAGE}"
+sed -i 's/openssl_conf = openssl_init/#openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
 
 # Setup a local user to run Salvo components.
 COMPONENT_DIR="/salvo/components"
-sudo groupadd salvo
-sudo useradd -ms /bin/bash -g salvo salvo
-sudo mkdir -p "${COMPONENT_DIR}"
+groupadd salvo
+useradd -ms /bin/bash -g salvo salvo
+mkdir -p "${COMPONENT_DIR}"
 
 # Install AzureCLI.
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 az extension add --name azure-devops
 az devops configure --defaults organization=https://dev.azure.com/cncf project=envoy
 
@@ -46,12 +46,12 @@ az pipelines runs artifact download \
   --path "${COMPONENT_DIR}"
 
 # Unpack the components and make them executable.
-sudo tar -xzf /salvo/components/envoy_binary.tar.gz -C /salvo/components/
-sudo ln -s /salvo/components/build_envoy_release/envoy /salvo/components/envoy
-sudo ln -s /salvo/components/build_envoy_release_stripped/envoy /salvo/components/envoy_stripped
-sudo chown -R salvo:salvo /salvo/
-sudo chmod 0755 /salvo/components/nighthawk*
+tar -xzf /salvo/components/envoy_binary.tar.gz -C /salvo/components/
+ln -s /salvo/components/build_envoy_release/envoy /salvo/components/envoy
+ln -s /salvo/components/build_envoy_release_stripped/envoy /salvo/components/envoy_stripped
+chown -R salvo:salvo /salvo/
+chmod 0755 /salvo/components/nighthawk*
 
 # Undo the libssl workaround done for AzureCLI.
-sudo sed -i 's/#openssl_conf = openssl_init/openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
-sudo dpkg -r $(dpkg -f "${LIBSSL1_PACKAGE}" Package)
+sed -i 's/#openssl_conf = openssl_init/openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
+dpkg -r $(dpkg -f "${LIBSSL1_PACKAGE}" Package)

--- a/salvo-remote/packer-ami-build/salvo-component-vm.sh
+++ b/salvo-remote/packer-ami-build/salvo-component-vm.sh
@@ -55,4 +55,3 @@ sudo chmod 0755 /salvo/components/nighthawk*
 # Undo the libssl workaround done for AzureCLI.
 sudo sed -i 's/#openssl_conf = openssl_init/openssl_conf = openssl_init/g' /etc/ssl/openssl.cnf
 sudo dpkg -r $(dpkg -f "${LIBSSL1_PACKAGE}" Package)
-


### PR DESCRIPTION
These scripts will be executed from the AZP pipeline added in https://github.com/envoyproxy/envoy-perf/pull/197.

Tested on AWS.