### PR TITLE
The salvo-mvp pipeline now executes the salvo-remote controller.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -121,6 +121,24 @@ function coverage_salvo_remote() {
   popd
 }
 
+# Package the salvo-remote binary and sandbox definitions into a zip file.
+function package_salvo_remote_and_sandboxes() {
+  echo "Packaging salvo-remote and sandboxes"
+  pushd salvo-remote
+
+  bazel build -c opt salvo-remote
+  cp bazel-bin/salvo-remote_/salvo-remote .
+  chmod 0755 salvo-remote
+  zip -r \
+    bazel-bin/salvo-remote.zip \
+    salvo-remote sandboxes/ \
+    -x \*/.terraform/\*
+
+  popd
+}
+
+
+
 # Set the build target. If no parameters are specified
 # we default to "build"
 build_target=${1:-build}
@@ -156,8 +174,11 @@ case $build_target in
   "coverage_salvo_remote")
     coverage_salvo_remote
     ;;
+  "package_salvo_remote_and_sandboxes")
+    package_salvo_remote_and_sandboxes
+    ;;
   *)
-    echo "must be one of [build, build_salvo_remote, test, test_salvo_remote, check_format, check_format_salvo_remote, fix_format, fix_format_salvo_remote, coverage, coverage_salvo_remote]"
+    echo "must be one of [build, build_salvo_remote, test, test_salvo_remote, check_format, check_format_salvo_remote, fix_format, fix_format_salvo_remote, coverage, coverage_salvo_remote, package_salvo_remote_and_sandboxes]"
     exit 1
     ;;
 esac

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -134,8 +134,8 @@ function package_salvo_remote_and_sandboxes() {
     salvo-remote sandboxes/ \
     -x \*/.terraform/\*
 
-  # This directory is created inside docker if we are running under
-  # ci/run_envoy_docker.sh.
+  # If we are running under ci/run_envoy_docker.sh, this is the only directory
+  # accessible by the host (outside of Docker).
   export BUILD_DIR="/build"
   if [ -d ${BUILD_DIR} ]; then
     cp bazel-bin/salvo-remote.zip ${BUILD_DIR}

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -134,6 +134,13 @@ function package_salvo_remote_and_sandboxes() {
     salvo-remote sandboxes/ \
     -x \*/.terraform/\*
 
+  # This directory is created inside docker if we are running under
+  # ci/run_envoy_docker.sh.
+  export BUILD_DIR="/build"
+  if [ -d ${BUILD_DIR} ]; then
+    cp bazel-bin/salvo-remote.zip ${BUILD_DIR}
+  fi
+
   popd
 }
 

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -55,9 +55,9 @@ steps:
 
 - ${{ if eq(parameters.repo, 'envoy-perf') }}:
   - bash: |
-      echo "ls in envoy-perf"
-      ls -laR "$(Build.StagingDirectory)/envoy-perf/"
-    displayName: "ls in envoy-perf"
+      echo "ls in Build.StagingDirectory"
+      ls -laR "$(Build.StagingDirectory)/"
+    displayName: "ls in Build.StagingDirectory"
     condition: always()
 
 # Publish the binaries as artifacts.

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -19,6 +19,10 @@ parameters:
   displayName: "Bazel extra build options"
   type: string
   default: ""
+- name: runInDocker
+  displayName: "Run the CI script inside Docker"
+  type: boolean
+  default: true
 
 steps:
 - bash: |
@@ -27,8 +31,9 @@ steps:
   displayName: "Check disk space at beginning"
 
 - script: "ci/run_envoy_docker.sh ci/do_ci.sh ${{ parameters.ciTarget }}"
+  condition: eq('${{ parameters.runInDocker }}', true)
   workingDirectory: "$(Build.SourcesDirectory)/${{ parameters.repo }}"
-  displayName: "CI script in ${{ parameters.repo }}"
+  displayName: "Run Dockerized CI script in ${{ parameters.repo }}"
   env:
     ENVOY_DOCKER_BUILD_DIR: $(Build.StagingDirectory)
     ${{ if parameters.rbe }}:
@@ -44,6 +49,13 @@ steps:
         BAZEL_REMOTE_INSTANCE: "instances/$(System.PullRequest.TargetBranch)"
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
         BAZEL_REMOTE_INSTANCE: "instances/$(Build.SourceBranchName)"
+
+- script: "ci/do_ci.sh ${{ parameters.ciTarget }}"
+  condition: eq('${{ parameters.runInDocker }}', false)
+  workingDirectory: "$(Build.SourcesDirectory)/${{ parameters.repo }}"
+  displayName: "Run CI script in ${{ parameters.repo }}"
+  env:
+    BAZEL_REMOTE_CACHE: $(LocalBuildCache)
 
 - bash: |
     echo "disk space at end of build:"
@@ -71,3 +83,9 @@ steps:
     inputs:
       targetPath: "$(Build.StagingDirectory)/envoy/x64/envoy_binary.tar.gz"
       artifactName: "Envoy server"
+- ${{ if eq(parameters.repo, 'envoy-perf') }}:
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish the salvo-remote controller and sandboxes"
+    inputs:
+      targetPath: "$(Build.StagingDirectory)/envoy-perf/salvo-remote/bazel-bin/salvo-remote.zip"
+      artifactName: "salvo-remote controller and sandboxes"

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -53,13 +53,6 @@ steps:
   displayName: "Check disk space at end"
   condition: always()
 
-- ${{ if eq(parameters.repo, 'envoy-perf') }}:
-  - bash: |
-      echo "ls in Build.StagingDirectory"
-      ls -laR "$(Build.StagingDirectory)/"
-    displayName: "ls in Build.StagingDirectory"
-    condition: always()
-
 # Publish the binaries as artifacts.
 - ${{ if eq(parameters.repo, 'nighthawk') }}:
   - task: PublishPipelineArtifact@1

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -1,4 +1,4 @@
-parameters:
+self:
 - name: ciTarget
   # The CI target to build, this is the $1 given to ci/do_ci.sh below.
   displayName: "CI target"

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -82,5 +82,5 @@ steps:
   - task: PublishPipelineArtifact@1
     displayName: "Publish the salvo-remote controller and sandboxes"
     inputs:
-      targetPath: "$(Build.StagingDirectory)/envoy-perf/salvo-remote/bazel-bin/salvo-remote.zip"
+      targetPath: "$(Build.StagingDirectory)/salvo-remote.zip"
       artifactName: "salvo-remote controller and sandboxes"

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -1,4 +1,4 @@
-self:
+parameters:
 - name: ciTarget
   # The CI target to build, this is the $1 given to ci/do_ci.sh below.
   displayName: "CI target"

--- a/salvo-remote/azure-pipelines/bazel.yml
+++ b/salvo-remote/azure-pipelines/bazel.yml
@@ -19,10 +19,6 @@ parameters:
   displayName: "Bazel extra build options"
   type: string
   default: ""
-- name: runInDocker
-  displayName: "Run the CI script inside Docker"
-  type: boolean
-  default: true
 
 steps:
 - bash: |
@@ -31,7 +27,6 @@ steps:
   displayName: "Check disk space at beginning"
 
 - script: "ci/run_envoy_docker.sh ci/do_ci.sh ${{ parameters.ciTarget }}"
-  condition: eq('${{ parameters.runInDocker }}', true)
   workingDirectory: "$(Build.SourcesDirectory)/${{ parameters.repo }}"
   displayName: "Run Dockerized CI script in ${{ parameters.repo }}"
   env:
@@ -50,13 +45,6 @@ steps:
       ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
         BAZEL_REMOTE_INSTANCE: "instances/$(Build.SourceBranchName)"
 
-- script: "ci/do_ci.sh ${{ parameters.ciTarget }}"
-  condition: eq('${{ parameters.runInDocker }}', false)
-  workingDirectory: "$(Build.SourcesDirectory)/${{ parameters.repo }}"
-  displayName: "Run CI script in ${{ parameters.repo }}"
-  env:
-    BAZEL_REMOTE_CACHE: $(LocalBuildCache)
-
 - bash: |
     echo "disk space at end of build:"
     df -h
@@ -64,6 +52,13 @@ steps:
     rm -rf $(Build.StagingDirectory)/tmp/*/*/external/go_sdk/test/fixedbugs
   displayName: "Check disk space at end"
   condition: always()
+
+- ${{ if eq(parameters.repo, 'envoy-perf') }}:
+  - bash: |
+      echo "ls in envoy-perf"
+      ls -laR "$(Build.StagingDirectory)/envoy-perf/"
+    displayName: "ls in envoy-perf"
+    condition: always()
 
 # Publish the binaries as artifacts.
 - ${{ if eq(parameters.repo, 'nighthawk') }}:

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -15,27 +15,27 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - ${{ if eq(variables['usePreviousBuildId2'], '') }}:
-    # Download salvo-remote from the current pipeline execution.
-    - task: DownloadPipelineArtifact@2
-      displayName: "Get current salvo-remote"
-      inputs:
-        buildType: "current"
-        artifactName: "salvo-remote controller and sandboxes"
-        targetPath: "$(System.ArtifactsDirectory)"
+  # Download salvo-remote from the current pipeline execution.
+  - task: DownloadPipelineArtifact@2
+    condition: $[ eq(variables['usePreviousBuildId2'], '') ]
+    displayName: "Get current salvo-remote"
+    inputs:
+      buildType: "current"
+      artifactName: "salvo-remote controller and sandboxes"
+      targetPath: "$(System.ArtifactsDirectory)"
 
-  - ${{ if ne(variables['usePreviousBuildId2'], '') }}:
-    # Download salvo-remote built in a previous pipeline execution.
-    - task: DownloadPipelineArtifact@2
-      displayName: "Get $(usePreviousBuildId) salvo-remote"
-      inputs:
-        buildType: "specific"
-        project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
-        definition: "58" # salvo-mvp
-        buildVersionToDownload: "specific"
-        pipelineId: "${{ parameters.usePreviousBuildId }}"
-        artifactName: "salvo-remote controller and sandboxes"
-        targetPath: "$(System.ArtifactsDirectory)"
+  # Download salvo-remote built in a previous pipeline execution.
+  - task: DownloadPipelineArtifact@2
+    condition: $[ ne(variables['usePreviousBuildId2'], '') ]
+    displayName: "Get previous salvo-remote"
+    inputs:
+      buildType: "specific"
+      project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
+      definition: "58" # salvo-mvp
+      buildVersionToDownload: "specific"
+      pipelineId: "${{ parameters.usePreviousBuildId }}"
+      artifactName: "salvo-remote controller and sandboxes"
+      targetPath: "$(System.ArtifactsDirectory)"
 
 
   - script: "unzip salvo-remote.zip"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -9,7 +9,7 @@ steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: "preheat the salvo-remote ASG"
+    displayName: "Preheat the salvo-remote ASG"
     env:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
@@ -40,7 +40,7 @@ steps:
 - ${{ if or(eq(parameters.action, 'run_current'), eq(parameters.action, 'run_previous')) }}:
   - script: "unzip salvo-remote.zip"
     workingDirectory: $(System.ArtifactsDirectory)
-    displayName: "unzip salvo-remote"
+    displayName: "Unzip salvo-remote"
 
   - script: "./salvo-remote -build_id_override '$(usePreviousBuildId)' -build_id '$(Build.BuildId)'"
     workingDirectory: $(System.ArtifactsDirectory)
@@ -49,7 +49,7 @@ steps:
 - ${{ if eq(parameters.action, 'cooldown') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh cooldown"
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: "cooldown the salvo-remote ASG"
+    displayName: "Cooldown the salvo-remote ASG"
     env:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -7,7 +7,29 @@ parameters:
 
 steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
-  - script: "salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
+  - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
+    workingDirectory: "$(Build.SourcesDirectory)"
+    displayName: "preheat the salvo-remote ASG"
+    env:
+      AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
+      AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
+
+- ${{ if eq(parameters.action, 'run') }}:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      buildType: $(usePreviousBuildId)
+      downloadType: 'single'
+      artifactName: 'salvo-remote controller and sandboxes'
+      downloadPath: '$(System.ArtifactsDirectory)'
+
+  - bash: |
+      echo "ls in System.ArtifactsDirectory:"
+      ls -laR "$(System.ArtifactsDirectory)"
+    displayName: "ls in System.ArtifactsDirectory"
+    condition: always()
+
+- ${{ if eq(parameters.action, 'cooldown') }}:
+  - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"
     env:

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -15,7 +15,7 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - ${{ if eq(variables.usePreviousBuildId, '') }}:
+  - ${{ if eq(variables['usePreviousBuildId'], '') }}:
     # Download salvo-remote from the current pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get current salvo-remote"
@@ -24,7 +24,7 @@ steps:
         artifactName: "salvo-remote controller and sandboxes"
         targetPath: "$(System.ArtifactsDirectory)"
 
-  - ${{ if ne(variables.usePreviousBuildId, '') }}:
+  - ${{ if ne(variables['usePreviousBuildId'], '') }}:
     - task: DownloadPipelineArtifact@2
       displayName: "Get $(usePreviousBuildId) salvo-remote"
     # Download salvo-remote built in a previous pipeline execution.

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -21,17 +21,11 @@ steps:
       artifactName: "salvo-remote controller and sandboxes"
       targetPath: "$(System.ArtifactsDirectory)"
 
-  - bash: |
-      echo "ls in System.ArtifactsDirectory:"
-      ls -laR "$(System.ArtifactsDirectory)"
-    displayName: "ls in System.ArtifactsDirectory"
-    condition: always()
-
   - script: "unzip salvo-remote.zip"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "unzip salvo-remote"
 
-  - script: "./salvo-remote -build_id_override $(usePreviousBuildId) -build_id $(Build.BuildId)"
+  - script: "./salvo-remote -build_id_override $(variables.usePreviousBuildId) -build_id $(Build.BuildId)"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -28,6 +28,14 @@ steps:
     displayName: "ls in System.ArtifactsDirectory"
     condition: always()
 
+  - script: "unzip salvo-remote.zip"
+    workingDirectory: $(System.ArtifactsDirectory)
+    displayName: "unzip salvo-remote"
+
+  - script: "./salvo-remote -build_type $(usePreviousBuildId) -build_id $(Build.BuildId)"
+    workingDirectory: $(System.ArtifactsDirectory)
+    displayName: "Run salvo-remote"
+
 - ${{ if eq(parameters.action, 'cooldown') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
     workingDirectory: "$(Build.SourcesDirectory)"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -1,0 +1,15 @@
+# Pipeline steps that execute the salvo-remote controller.
+parameters:
+- name: action
+  displayName: "The action to perform"
+  type: string
+  default: ""
+
+steps:
+- ${{ if eq(parameters.action, 'preheat') }}:
+  - script: "salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
+    workingDirectory: "$(Build.SourcesDirectory)"
+    displayName: "preheat the salvo-remote ASG"
+    env:
+      AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
+      AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -6,7 +6,7 @@ parameters:
   default: ""
 
 steps:
-- ${{ if eq(parameters.action, "preheat") }}:
+- ${{ if eq(parameters.action, 'preheat') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"
@@ -14,7 +14,7 @@ steps:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
-- ${{ if eq(parameters.action, "run") }}:
+- ${{ if eq(parameters.action, 'run') }}:
   - task: DownloadPipelineArtifact@2
     inputs:
       buildType: "current"
@@ -35,7 +35,7 @@ steps:
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 
-- ${{ if eq(parameters.action, "cooldown") }}:
+- ${{ if eq(parameters.action, 'cooldown') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh cooldown"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -4,6 +4,10 @@ parameters:
   displayName: "The action to perform, must be one of [preheat, run, cooldown]."
   type: string
   default: ""
+- name: usePreviousBuildId
+  displayName: "Allows using components built in a a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build."
+  type: string
+  default: ""
 
 steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
@@ -25,7 +29,7 @@ steps:
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "unzip salvo-remote"
 
-  - script: "./salvo-remote -build_id_override $(variables.usePreviousBuildId) -build_id $(Build.BuildId)"
+  - script: "./salvo-remote -build_id_override $(usePreviousBuildId) -build_id $(Build.BuildId)"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -49,7 +49,7 @@ steps:
 - ${{ if eq(parameters.action, 'cooldown') }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh cooldown"
     workingDirectory: "$(Build.SourcesDirectory)"
-    displayName: "preheat the salvo-remote ASG"
+    displayName: "cooldown the salvo-remote ASG"
     env:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -4,6 +4,10 @@ parameters:
   displayName: "The action to perform, must be one of [preheat, run, cooldown]."
   type: string
   default: ""
+- name: usePreviousBuildId
+  displayName: "Allows using components built in a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build. Defaults to an empty string in which case Salvo runs with components built by the current pipeline execution."
+  type: string
+  default: ""
 
 steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
@@ -15,7 +19,7 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - ${{ if eq(variables['usePreviousBuildId'], '') }}:
+  - ${{ if eq(parameters.usePreviousBuildId, '') }}:
     # Download salvo-remote from the current pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get current salvo-remote"
@@ -24,7 +28,7 @@ steps:
         artifactName: "salvo-remote controller and sandboxes"
         targetPath: "$(System.ArtifactsDirectory)"
 
-  - ${{ if ne(variables['usePreviousBuildId'], '') }}:
+  - ${{ if ne(parameters.usePreviousBuildId, '') }}:
     - task: DownloadPipelineArtifact@2
       displayName: "Get $(usePreviousBuildId) salvo-remote"
     # Download salvo-remote built in a previous pipeline execution.
@@ -33,7 +37,7 @@ steps:
         project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
         definition: "58" # salvo-mvp
         buildVersionToDownload: "specific"
-        pipelineId: "$(usePreviousBuildId)"
+        pipelineId: "${{ parameters.usePreviousBuildId }}"
         artifactName: "salvo-remote controller and sandboxes"
         targetPath: "$(System.ArtifactsDirectory)"
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -15,12 +15,11 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - task: DownloadBuildArtifacts@0
+  - task: DownloadPipelineArtifact@2
     inputs:
       buildType: $(usePreviousBuildId)
-      downloadType: 'single'
       artifactName: 'salvo-remote controller and sandboxes'
-      downloadPath: '$(System.ArtifactsDirectory)'
+      targetPath: '$(System.ArtifactsDirectory)'
 
   - bash: |
       echo "ls in System.ArtifactsDirectory:"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -1,12 +1,12 @@
 # Pipeline steps that execute the salvo-remote controller.
 parameters:
 - name: action
-  displayName: "The action to perform"
+  displayName: "The action to perform, must be one of [preheat, run, cooldown]."
   type: string
   default: ""
 
 steps:
-- ${{ if eq(parameters.action, 'preheat') }}:
+- ${{ if eq(parameters.action, "preheat") }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"
@@ -14,12 +14,12 @@ steps:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
-- ${{ if eq(parameters.action, 'run') }}:
+- ${{ if eq(parameters.action, "run") }}:
   - task: DownloadPipelineArtifact@2
     inputs:
-      buildType: $(usePreviousBuildId)
-      artifactName: 'salvo-remote controller and sandboxes'
-      targetPath: '$(System.ArtifactsDirectory)'
+      buildType: "current"
+      artifactName: "salvo-remote controller and sandboxes"
+      targetPath: "$(System.ArtifactsDirectory)"
 
   - bash: |
       echo "ls in System.ArtifactsDirectory:"
@@ -35,7 +35,7 @@ steps:
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 
-- ${{ if eq(parameters.action, 'cooldown') }}:
+- ${{ if eq(parameters.action, "cooldown") }}:
   - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh cooldown"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -37,7 +37,7 @@ steps:
     displayName: "Run salvo-remote"
 
 - ${{ if eq(parameters.action, 'cooldown') }}:
-  - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh preheat"
+  - script: "envoy-perf/salvo-remote/azure-pipelines/scripts/asg_control.sh cooldown"
     workingDirectory: "$(Build.SourcesDirectory)"
     displayName: "preheat the salvo-remote ASG"
     env:

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -33,7 +33,7 @@ steps:
       project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
       definition: "58" # salvo-mvp
       buildVersionToDownload: "specific"
-      pipelineId: "${{ parameters.usePreviousBuildId }}"
+      pipelineId: "$(usePreviousBuildId2)"
       artifactName: "salvo-remote controller and sandboxes"
       targetPath: "$(System.ArtifactsDirectory)"
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -4,10 +4,6 @@ parameters:
   displayName: "The action to perform, must be one of [preheat, run, cooldown]."
   type: string
   default: ""
-- name: usePreviousBuildId
-  displayName: "Allows using components built in a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build. Defaults to an empty string in which case Salvo runs with components built by the current pipeline execution."
-  type: string
-  default: ""
 
 steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
@@ -19,7 +15,7 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - ${{ if eq(parameters.usePreviousBuildId, '') }}:
+  - $[if eq(variables.usePreviousBuildId2, '')]:
     # Download salvo-remote from the current pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get current salvo-remote"
@@ -28,7 +24,7 @@ steps:
         artifactName: "salvo-remote controller and sandboxes"
         targetPath: "$(System.ArtifactsDirectory)"
 
-  - ${{ if ne(parameters.usePreviousBuildId, '') }}:
+  - $[if ne(variables.usePreviousBuildId2, '')]:
     # Download salvo-remote built in a previous pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get $(usePreviousBuildId) salvo-remote"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -1,7 +1,7 @@
 # Pipeline steps that execute the salvo-remote controller.
 parameters:
 - name: action
-  displayName: "The action to perform, must be one of [preheat, run, cooldown]."
+  displayName: "The action to perform, must be one of [preheat, run_current, run_previous, cooldown]."
   type: string
   default: ""
 
@@ -14,30 +14,30 @@ steps:
       AWS_ACCESS_KEY_ID: $(SalvoAwsAccessKeyId)
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
-- ${{ if eq(parameters.action, 'run') }}:
+- ${{ if eq(parameters.action, 'run_current') }}:
   # Download salvo-remote from the current pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: ${{ eq(variables['usePreviousBuildId2'], '137775') }}
     displayName: "Get current salvo-remote"
     inputs:
       buildType: "current"
       artifactName: "salvo-remote controller and sandboxes"
       targetPath: "$(System.ArtifactsDirectory)"
 
+- ${{ if eq(parameters.action, 'run_previous') }}:
   # Download salvo-remote built in a previous pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: ${{ ne(variables['usePreviousBuildId2'], '137776') }}
     displayName: "Get previous salvo-remote"
     inputs:
       buildType: "specific"
       project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
       definition: "58" # salvo-mvp
       buildVersionToDownload: "specific"
-      pipelineId: "$(usePreviousBuildId2)"
+      pipelineId: "$(usePreviousBuildId)"
       artifactName: "salvo-remote controller and sandboxes"
       targetPath: "$(System.ArtifactsDirectory)"
 
 
+- ${{ if or(eq(parameters.action, 'run_current'), eq(parameters.action, 'run_previous')) }}:
   - script: "unzip salvo-remote.zip"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "unzip salvo-remote"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -5,7 +5,7 @@ parameters:
   type: string
   default: ""
 - name: usePreviousBuildId
-  displayName: "Allows using components built in a a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build."
+  displayName: "Allows using components built in a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build. Defaults to an empty string in which case Salvo runs with components built by the current pipeline execution."
   type: string
   default: ""
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -29,9 +29,9 @@ steps:
         targetPath: "$(System.ArtifactsDirectory)"
 
   - ${{ if ne(parameters.usePreviousBuildId, '') }}:
+    # Download salvo-remote built in a previous pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get $(usePreviousBuildId) salvo-remote"
-    # Download salvo-remote built in a previous pipeline execution.
       inputs:
         buildType: "specific"
         project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -17,7 +17,7 @@ steps:
 - ${{ if eq(parameters.action, 'run') }}:
   # Download salvo-remote from the current pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: $[ eq(variables['usePreviousBuildId2'], '') ]
+    condition: ${{ eq(variables['usePreviousBuildId2'], '') }}
     displayName: "Get current salvo-remote"
     inputs:
       buildType: "current"
@@ -26,7 +26,7 @@ steps:
 
   # Download salvo-remote built in a previous pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: $[ ne(variables['usePreviousBuildId2'], '') ]
+    condition: ${{ ne(variables['usePreviousBuildId2'], '') }}
     displayName: "Get previous salvo-remote"
     inputs:
       buildType: "specific"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -17,7 +17,7 @@ steps:
 - ${{ if eq(parameters.action, 'run') }}:
   # Download salvo-remote from the current pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: ${{ eq(variables['usePreviousBuildId2'], '') }}
+    condition: ${{ eq(variables['usePreviousBuildId2'], '137775') }}
     displayName: "Get current salvo-remote"
     inputs:
       buildType: "current"
@@ -26,7 +26,7 @@ steps:
 
   # Download salvo-remote built in a previous pipeline execution.
   - task: DownloadPipelineArtifact@2
-    condition: ${{ ne(variables['usePreviousBuildId2'], '') }}
+    condition: ${{ ne(variables['usePreviousBuildId2'], '137776') }}
     displayName: "Get previous salvo-remote"
     inputs:
       buildType: "specific"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -15,7 +15,7 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - $[if eq(variables.usePreviousBuildId2, '')]:
+  - ${{ if eq(variables['usePreviousBuildId2'], '') }}:
     # Download salvo-remote from the current pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get current salvo-remote"
@@ -24,7 +24,7 @@ steps:
         artifactName: "salvo-remote controller and sandboxes"
         targetPath: "$(System.ArtifactsDirectory)"
 
-  - $[if ne(variables.usePreviousBuildId2, '')]:
+  - ${{ if ne(variables['usePreviousBuildId2'], '') }}:
     # Download salvo-remote built in a previous pipeline execution.
     - task: DownloadPipelineArtifact@2
       displayName: "Get $(usePreviousBuildId) salvo-remote"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -32,7 +32,7 @@ steps:
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "unzip salvo-remote"
 
-  - script: "./salvo-remote -build_type $(usePreviousBuildId) -build_id $(Build.BuildId)"
+  - script: "./salvo-remote -build_id_override $(usePreviousBuildId) -build_id $(Build.BuildId)"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -15,11 +15,26 @@ steps:
       AWS_SECRET_ACCESS_KEY: $(SalvoAwsSecretAccessKey)
 
 - ${{ if eq(parameters.action, 'run') }}:
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      buildType: "current"
-      artifactName: "salvo-remote controller and sandboxes"
-      targetPath: "$(System.ArtifactsDirectory)"
+  - ${{ if eq(variables.usePreviousBuildId, '') }}:
+    # Download salvo-remote from the current pipeline execution.
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: "current"
+        artifactName: "salvo-remote controller and sandboxes"
+        targetPath: "$(System.ArtifactsDirectory)"
+
+  - ${{ if ne(variables.usePreviousBuildId, '') }}:
+    - task: DownloadPipelineArtifact@2
+    # Download salvo-remote built in a previous pipeline execution.
+      inputs:
+        buildType: "specific"
+        project: "4684fb3d-0389-4e0b-8251-221942316e06" # envoy
+        definition: "58" # salvo-mvp
+        buildVersionToDownload: "specific"
+        pipelineId: "$(usePreviousBuildId)"
+        artifactName: "salvo-remote controller and sandboxes"
+        targetPath: "$(System.ArtifactsDirectory)"
+
 
   - script: "unzip salvo-remote.zip"
     workingDirectory: $(System.ArtifactsDirectory)

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -18,6 +18,7 @@ steps:
   - ${{ if eq(variables.usePreviousBuildId, '') }}:
     # Download salvo-remote from the current pipeline execution.
     - task: DownloadPipelineArtifact@2
+      displayName: "Get current salvo-remote"
       inputs:
         buildType: "current"
         artifactName: "salvo-remote controller and sandboxes"
@@ -25,6 +26,7 @@ steps:
 
   - ${{ if ne(variables.usePreviousBuildId, '') }}:
     - task: DownloadPipelineArtifact@2
+      displayName: "Get $(usePreviousBuildId) salvo-remote"
     # Download salvo-remote built in a previous pipeline execution.
       inputs:
         buildType: "specific"

--- a/salvo-remote/azure-pipelines/salvo_controller.yml
+++ b/salvo-remote/azure-pipelines/salvo_controller.yml
@@ -4,10 +4,6 @@ parameters:
   displayName: "The action to perform, must be one of [preheat, run, cooldown]."
   type: string
   default: ""
-- name: usePreviousBuildId
-  displayName: "Allows using components built in a previous pipeline execution. If set to an AZP Build ID, Salvo will run with components created in the specified build. Defaults to an empty string in which case Salvo runs with components built by the current pipeline execution."
-  type: string
-  default: ""
 
 steps:
 - ${{ if eq(parameters.action, 'preheat') }}:
@@ -29,7 +25,7 @@ steps:
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "unzip salvo-remote"
 
-  - script: "./salvo-remote -build_id_override $(usePreviousBuildId) -build_id $(Build.BuildId)"
+  - script: "./salvo-remote -build_id_override '$(usePreviousBuildId)' -build_id '$(Build.BuildId)'"
     workingDirectory: $(System.ArtifactsDirectory)
     displayName: "Run salvo-remote"
 

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -62,7 +62,7 @@ stages:
   pool: "envoy-x64-large"
   jobs:
   - job: "build_salvo_remote"
-    displayName: "Build salvo-remote and preheat ASG"
+    displayName: "Build salvo-remote and preheat the salvo-control ASG"
     timeoutInMinutes: 120
     steps:
     - checkout: "nighthawk"
@@ -89,3 +89,18 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
+
+- stage: "cooldown_salvo_asg"
+  dependsOn: ["run_salvo_remote"]
+  condition: always()
+  pool: "envoy-x64-large"
+  jobs:
+  - job: "cooldown_salvo_asg"
+    displayName: "Cooldown the salvo-control ASG"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "salvo_controller.yml"
+      parameters:
+        action: "cooldown"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -7,6 +7,15 @@
 
 # Salvo builds the Nighthawk (load generator), The Envoy (system under test)
 # and the Nighthawk test server (the fake backend).
+#
+# Pipeline variable usePreviousBuildId is used for debugging.
+#   - When set to an empty value, all components are built, ASG is pre-heated,
+#     salvo-remote is executed with the built components and the ASG is cooled
+#     down.
+#   - When set to an AZP pipeline build ID, component building, pre-heating and
+#     cooling down is skipped. Salvo-remote gets executed with components built
+#     in a previous pipeline execution identified by the value if
+#     usePreviousBuildId.
 resources:
   repositories:
     - repository: "nighthawk"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -105,7 +105,8 @@ stages:
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]
-  condition: always()
+  #condition: always()
+  condition: eq(1,2)
   pool: "envoy-x64-large"
   jobs:
   - job: "cooldown_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -62,7 +62,7 @@ stages:
   pool: "envoy-x64-large"
   jobs:
   - job: "build_salvo_remote"
-    displayName: "Build salvo-remote"
+    displayName: "Build salvo-remote and preheat ASG"
     timeoutInMinutes: 120
     steps:
     - checkout: "nighthawk"
@@ -75,3 +75,17 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "preheat"
+
+- stage: "run_salvo_remote"
+  dependsOn: ["build_salvo_remote"]
+  pool: "salvo-control"
+  jobs:
+  - job: "run_salvo_remote"
+    displayName: "Run salvo-remote"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "salvo_controller.yml"
+      parameters:
+        action: "run"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -100,7 +100,7 @@ stages:
 
 - stage: "run_current_salvo_remote"
   dependsOn: ["build_amis", "build_salvo_remote", "preheat_salvo_asg"]
-  condition: eq(variables.usePreviousBuildId2, '')
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "salvo-control"
   jobs:
   - job: "run_current_salvo_remote"
@@ -115,7 +115,7 @@ stages:
 
 - stage: "run_previous_salvo_remote"
   dependsOn: ["build_amis", "build_salvo_remote", "preheat_salvo_asg"]
-  condition: ne(variables.usePreviousBuildId2, '')
+  condition: ne(variables.usePreviousBuildId, '')
   pool: "salvo-control"
   jobs:
   - job: "run_previous_salvo_remote"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -9,11 +9,13 @@
 # and the Nighthawk test server (the fake backend).
 #
 # Pipeline variable usePreviousBuildId is used for debugging.
-#   - When set to an empty value, all components are built, and salvo-remote is
-#     executed with the built components.
-#   - When set to an AZP pipeline build ID, component building is skipped.
-#     Salvo-remote gets executed with components built in a previous pipeline
-#     execution identified by the value if usePreviousBuildId.
+#   - When set to an empty value, all components are built, ASG is pre-heated,
+#     salvo-remote is executed with the built components and the ASG is cooled
+#     down.
+#   - When set to an AZP pipeline build ID, component building, pre-heating and
+#     cooling down is skipped. Salvo-remote gets executed with components built
+#     in a previous pipeline execution identified by the value if
+#     usePreviousBuildId.
 resources:
   repositories:
     - repository: "nighthawk"
@@ -83,6 +85,7 @@ stages:
 
 - stage: "preheat_salvo_asg"
   dependsOn: []
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "preheat_salvo_asg"
@@ -127,6 +130,7 @@ stages:
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_current_salvo_remote", "run_previous_salvo_remote"]
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "cooldown_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -48,7 +48,7 @@ stages:
 
 - stage: "build_amis"
   dependsOn: ["build_components"]
-  condition: never()
+  condition: eq(1, 2)
   pool:
     vmImage: "ubuntu-22.04"
   jobs:

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -76,7 +76,6 @@ stages:
 
 - stage: "preheat_salvo_asg"
   dependsOn: ["build_salvo_remote"]
-  condition: always()
   pool: "envoy-x64-large"
   jobs:
   - job: "preheat_salvo_asg"
@@ -91,6 +90,7 @@ stages:
 
 - stage: "run_salvo_remote"
   dependsOn: ["preheat_salvo_asg"]
+  condition: always()
   pool: "salvo-control"
   jobs:
   - job: "run_salvo_remote"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -75,7 +75,7 @@ stages:
         ciTarget: "package_salvo_remote_and_sandboxes"
 
 - stage: "preheat_salvo_asg"
-  dependsOn: ["build_salvo_remote"]
+  dependsOn: []
   pool: "envoy-x64-large"
   jobs:
   - job: "preheat_salvo_asg"
@@ -89,7 +89,7 @@ stages:
         action: "preheat"
 
 - stage: "run_salvo_remote"
-  dependsOn: ["preheat_salvo_asg"]
+  dependsOn: ["build_components", "build_salvo_remote", "preheat_salvo_asg"]
   condition: always()
   pool: "salvo-control"
   jobs:

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -112,7 +112,7 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
-        usePreviousBuildId: "$(usePreviousBuildId)"
+        usePreviousBuildId: "$(usePreviousBuildId2)"
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -17,6 +17,10 @@ resources:
       type: "github"
       endpoint: "GitHub - mum4k - Salvo MVP"
       name: "envoyproxy/envoy"
+    - repository: "envoy-perf"
+      type: "github"
+      endpoint: "GitHub - mum4k - Salvo MVP"
+      name: "envoyproxy/envoy-perf"
 
 stages:
 - stage: "build_components"
@@ -29,6 +33,7 @@ stages:
     steps:
     - checkout: "nighthawk"
     - checkout: "envoy"
+    - checkout: "envoy-perf"
     #- template: "bazel.yml"
     #  parameters:
     #    rbe: false

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -21,7 +21,7 @@ resources:
 stages:
 - stage: "build_components"
   dependsOn: []
-  condition: eq(variables.usePreviousBuildId, '12345')
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "build_components"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -72,22 +72,6 @@ stages:
         rbe: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
-
-- stage: "build_salvo_remote"
-  dependsOn: []
-  pool: "envoy-x64-large"
-  jobs:
-  - job: "build_salvo_remote"
-    displayName: "Build salvo-remote and preheat ASG"
-    timeoutInMinutes: 120
-    steps:
-    - checkout: "nighthawk"
-    - checkout: "self"
-    - template: "bazel.yml"
-      parameters:
-        rbe: false
-        repo: "envoy-perf"
-        ciTarget: "package_salvo_remote_and_sandboxes"
     - template: "salvo_controller.yml"
       parameters:
         action: "preheat"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -105,8 +105,7 @@ stages:
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]
-  #condition: always()
-  condition: eq(1,2)
+  condition: eq(variables.usePreviousBuildId, '12345')
   pool: "envoy-x64-large"
   jobs:
   - job: "cooldown_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -17,14 +17,11 @@ resources:
       type: "github"
       endpoint: "GitHub - mum4k - Salvo MVP"
       name: "envoyproxy/envoy"
-    - repository: "envoy-perf"
-      type: "github"
-      endpoint: "GitHub - mum4k - Salvo MVP"
-      name: "envoyproxy/envoy-perf"
 
 stages:
 - stage: "build_components"
   dependsOn: []
+  condition: eq(1, 2)
   pool: "envoy-x64-large"
   jobs:
   - job: "build_components"
@@ -33,23 +30,41 @@ stages:
     steps:
     - checkout: "nighthawk"
     - checkout: "envoy"
-    - checkout: "envoy-perf"
-    #- template: "bazel.yml"
-    #  parameters:
-    #    rbe: false
-    #    repo: "nighthawk"
-    #    ciTarget: "opt_build"
-    #- template: "bazel.yml"
-    #  parameters:
-    #    rbe: true
-    #    repo: "envoy"
-    #    ciTarget: "bazel.release.server_only"
+    - template: "bazel.yml"
+      parameters:
+        rbe: false
+        repo: "nighthawk"
+        ciTarget: "opt_build"
+    - template: "bazel.yml"
+      parameters:
+        rbe: true
+        repo: "envoy"
+        ciTarget: "bazel.release.server_only"
     - template: "bazel.yml"
       parameters:
         rbe: false
         runInDocker: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
+
+- stage: "build_salvo_remote"
+  dependsOn: []
+  pool:
+    vmImage: "ubuntu-22.04"
+  jobs:
+  - job: "build_salvo_remote"
+    displayName: "Build salvo-remote"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "bazel.yml"
+      parameters:
+        rbe: false
+        runInDocker: false
+        repo: "envoy-perf"
+        ciTarget: "package_salvo_remote_and_sandboxes"
+
 
 - stage: "build_amis"
   dependsOn: ["build_components"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -59,20 +59,32 @@ stages:
 
 - stage: "build_salvo_remote"
   dependsOn: []
+  condition: eq(variables.usePreviousBuildId, '12345')
   pool: "envoy-x64-large"
   jobs:
   - job: "build_salvo_remote"
-    displayName: "Build salvo-remote and preheat the salvo-control ASG"
+    displayName: "Build salvo-remote"
     timeoutInMinutes: 120
     steps:
     - checkout: "nighthawk"
     - checkout: "self"
     - template: "bazel.yml"
-      condition: eq(variables.usePreviousBuildId, '12345')
       parameters:
         rbe: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
+
+- stage: "preheat_salvo_asg"
+  dependsOn: ["build_salvo_remote"]
+  condition: always()
+  pool: "envoy-x64-large"
+  jobs:
+  - job: "preheat_salvo_asg"
+    displayName: "Preheat the salvo-control ASG"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
     - template: "salvo_controller.yml"
       parameters:
         action: "preheat"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -72,3 +72,22 @@ stages:
         rbe: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
+
+- stage: "build_salvo_remote"
+  dependsOn: []
+  pool: "envoy-x64-large"
+  jobs:
+  - job: "build_salvo_remote"
+    displayName: "Build salvo-remote and preheat ASG"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "bazel.yml"
+      parameters:
+        rbe: false
+        repo: "envoy-perf"
+        ciTarget: "package_salvo_remote_and_sandboxes"
+    - template: "salvo_controller.yml"
+      parameters:
+        action: "preheat"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -43,7 +43,7 @@ stages:
     - template: "bazel.yml"
       parameters:
         rbe: false
-        runInDocker: false
+        runInDocker: true
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
 

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -43,7 +43,6 @@ stages:
     - template: "bazel.yml"
       parameters:
         rbe: false
-        runInDocker: true
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
 

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -21,6 +21,7 @@ resources:
 stages:
 - stage: "build_components"
   dependsOn: []
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "build_components"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -68,6 +68,7 @@ stages:
     - checkout: "nighthawk"
     - checkout: "self"
     - template: "bazel.yml"
+      condition: eq(variables.usePreviousBuildId, '12345')
       parameters:
         rbe: false
         repo: "envoy-perf"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -89,7 +89,7 @@ stages:
         action: "preheat"
 
 - stage: "run_salvo_remote"
-  dependsOn: ["build_components", "build_salvo_remote", "preheat_salvo_asg"]
+  dependsOn: ["build_amis", "build_salvo_remote", "preheat_salvo_asg"]
   condition: always()
   pool: "salvo-control"
   jobs:

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -42,11 +42,13 @@ stages:
     - template: "bazel.yml"
       parameters:
         rbe: false
+        runInDocker: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
 
 - stage: "build_amis"
   dependsOn: ["build_components"]
+  condition: never()
   pool:
     vmImage: "ubuntu-22.04"
   jobs:

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -76,6 +76,7 @@ stages:
 
 - stage: "preheat_salvo_asg"
   dependsOn: []
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "preheat_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -21,7 +21,7 @@ resources:
 stages:
 - stage: "build_components"
   dependsOn: []
-  condition: eq(variables.usePreviousBuildId, '')
+  condition: eq(variables.usePreviousBuildId, '12345')
   pool: "envoy-x64-large"
   jobs:
   - job: "build_components"
@@ -31,25 +31,20 @@ stages:
     - checkout: "nighthawk"
     - checkout: "envoy"
     - checkout: "self"
-    #- template: "bazel.yml"
-    #  parameters:
-    #    rbe: false
-    #    repo: "nighthawk"
-    #    ciTarget: "opt_build"
-    #- template: "bazel.yml"
-    #  parameters:
-    #    rbe: true
-    #    repo: "envoy"
-    #    ciTarget: "bazel.release.server_only"
     - template: "bazel.yml"
       parameters:
         rbe: false
-        repo: "envoy-perf"
-        ciTarget: "package_salvo_remote_and_sandboxes"
+        repo: "nighthawk"
+        ciTarget: "opt_build"
+    - template: "bazel.yml"
+      parameters:
+        rbe: true
+        repo: "envoy"
+        ciTarget: "bazel.release.server_only"
 
 - stage: "build_amis"
   dependsOn: ["build_components"]
-  condition: eq(1, 2)
+  condition: eq(variables.usePreviousBuildId, '12345')
   pool:
     vmImage: "ubuntu-22.04"
   jobs:
@@ -61,3 +56,19 @@ stages:
       parameters:
         repo: "nighthawk"
         ciTarget: "opt_build"
+
+- stage: "build_salvo_remote"
+  dependsOn: []
+  pool: "envoy-x64-large"
+  jobs:
+  - job: "build_salvo_remote"
+    displayName: "Build salvo-remote"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "bazel.yml"
+      parameters:
+        rbe: false
+        repo: "envoy-perf"
+        ciTarget: "package_salvo_remote_and_sandboxes"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -90,7 +90,7 @@ stages:
         action: "preheat"
 
 - stage: "run_salvo_remote"
-  dependsOn: ["build_salvo_remote"]
+  dependsOn: ["preheat_salvo_asg"]
   pool: "salvo-control"
   jobs:
   - job: "run_salvo_remote"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -29,16 +29,21 @@ stages:
     steps:
     - checkout: "nighthawk"
     - checkout: "envoy"
+    #- template: "bazel.yml"
+    #  parameters:
+    #    rbe: false
+    #    repo: "nighthawk"
+    #    ciTarget: "opt_build"
+    #- template: "bazel.yml"
+    #  parameters:
+    #    rbe: true
+    #    repo: "envoy"
+    #    ciTarget: "bazel.release.server_only"
     - template: "bazel.yml"
       parameters:
         rbe: false
-        repo: "nighthawk"
-        ciTarget: "opt_build"
-    - template: "bazel.yml"
-      parameters:
-        rbe: true
-        repo: "envoy"
-        ciTarget: "bazel.release.server_only"
+        repo: "envoy-perf"
+        ciTarget: "package_salvo_remote_and_sandboxes"
 
 - stage: "build_amis"
   dependsOn: ["build_components"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -102,6 +102,7 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
+        usePreviousBuildId: "$(usePreviousBuildId)"
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -44,7 +44,7 @@ stages:
 
 - stage: "build_amis"
   dependsOn: ["build_components"]
-  condition: eq(variables.usePreviousBuildId, '12345')
+  condition: eq(variables.usePreviousBuildId, '')
   pool:
     vmImage: "ubuntu-22.04"
   jobs:
@@ -59,7 +59,7 @@ stages:
 
 - stage: "build_salvo_remote"
   dependsOn: []
-  condition: eq(variables.usePreviousBuildId, '12345')
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "build_salvo_remote"
@@ -106,7 +106,7 @@ stages:
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]
-  condition: eq(variables.usePreviousBuildId, '12345')
+  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "cooldown_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -21,7 +21,6 @@ resources:
 stages:
 - stage: "build_components"
   dependsOn: []
-  condition: eq(1, 2)
   pool: "envoy-x64-large"
   jobs:
   - job: "build_components"
@@ -30,41 +29,23 @@ stages:
     steps:
     - checkout: "nighthawk"
     - checkout: "envoy"
-    - template: "bazel.yml"
-      parameters:
-        rbe: false
-        repo: "nighthawk"
-        ciTarget: "opt_build"
-    - template: "bazel.yml"
-      parameters:
-        rbe: true
-        repo: "envoy"
-        ciTarget: "bazel.release.server_only"
-    - template: "bazel.yml"
-      parameters:
-        rbe: false
-        runInDocker: false
-        repo: "envoy-perf"
-        ciTarget: "package_salvo_remote_and_sandboxes"
-
-- stage: "build_salvo_remote"
-  dependsOn: []
-  pool:
-    vmImage: "ubuntu-22.04"
-  jobs:
-  - job: "build_salvo_remote"
-    displayName: "Build salvo-remote"
-    timeoutInMinutes: 120
-    steps:
-    - checkout: "nighthawk"
     - checkout: "self"
+    #- template: "bazel.yml"
+    #  parameters:
+    #    rbe: false
+    #    repo: "nighthawk"
+    #    ciTarget: "opt_build"
+    #- template: "bazel.yml"
+    #  parameters:
+    #    rbe: true
+    #    repo: "envoy"
+    #    ciTarget: "bazel.release.server_only"
     - template: "bazel.yml"
       parameters:
         rbe: false
         runInDocker: false
         repo: "envoy-perf"
         ciTarget: "package_salvo_remote_and_sandboxes"
-
 
 - stage: "build_amis"
   dependsOn: ["build_components"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -112,7 +112,6 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
-        usePreviousBuildId: "$(usePreviousBuildId2)"
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -9,13 +9,11 @@
 # and the Nighthawk test server (the fake backend).
 #
 # Pipeline variable usePreviousBuildId is used for debugging.
-#   - When set to an empty value, all components are built, ASG is pre-heated,
-#     salvo-remote is executed with the built components and the ASG is cooled
-#     down.
-#   - When set to an AZP pipeline build ID, component building, pre-heating and
-#     cooling down is skipped. Salvo-remote gets executed with components built
-#     in a previous pipeline execution identified by the value if
-#     usePreviousBuildId.
+#   - When set to an empty value, all components are built, and salvo-remote is
+#     executed with the built components.
+#   - When set to an AZP pipeline build ID, component building is skipped.
+#     Salvo-remote gets executed with components built in a previous pipeline
+#     execution identified by the value if usePreviousBuildId.
 resources:
   repositories:
     - repository: "nighthawk"
@@ -85,7 +83,6 @@ stages:
 
 - stage: "preheat_salvo_asg"
   dependsOn: []
-  condition: eq(variables.usePreviousBuildId, '')
   pool: "envoy-x64-large"
   jobs:
   - job: "preheat_salvo_asg"
@@ -98,24 +95,38 @@ stages:
       parameters:
         action: "preheat"
 
-- stage: "run_salvo_remote"
+- stage: "run_current_salvo_remote"
   dependsOn: ["build_amis", "build_salvo_remote", "preheat_salvo_asg"]
-  condition: always()
+  condition: eq(variables.usePreviousBuildId2, '')
   pool: "salvo-control"
   jobs:
-  - job: "run_salvo_remote"
-    displayName: "Run salvo-remote"
+  - job: "run_current_salvo_remote"
+    displayName: "Run current salvo-remote"
     timeoutInMinutes: 120
     steps:
     - checkout: "nighthawk"
     - checkout: "self"
     - template: "salvo_controller.yml"
       parameters:
-        action: "run"
+        action: "run_current"
+
+- stage: "run_previous_salvo_remote"
+  dependsOn: ["build_amis", "build_salvo_remote", "preheat_salvo_asg"]
+  condition: ne(variables.usePreviousBuildId2, '')
+  pool: "salvo-control"
+  jobs:
+  - job: "run_previous_salvo_remote"
+    displayName: "Run previous salvo-remote"
+    timeoutInMinutes: 120
+    steps:
+    - checkout: "nighthawk"
+    - checkout: "self"
+    - template: "salvo_controller.yml"
+      parameters:
+        action: "run_previous"
 
 - stage: "cooldown_salvo_asg"
-  dependsOn: ["run_salvo_remote"]
-  condition: eq(variables.usePreviousBuildId, '')
+  dependsOn: ["run_current_salvo_remote", "run_previous_salvo_remote"]
   pool: "envoy-x64-large"
   jobs:
   - job: "cooldown_salvo_asg"

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -89,6 +89,7 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
+        usePreviousBuildId: $(usePreviousBuildId)
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]

--- a/salvo-remote/azure-pipelines/salvo_pipelines.yml
+++ b/salvo-remote/azure-pipelines/salvo_pipelines.yml
@@ -89,7 +89,6 @@ stages:
     - template: "salvo_controller.yml"
       parameters:
         action: "run"
-        usePreviousBuildId: $(usePreviousBuildId)
 
 - stage: "cooldown_salvo_asg"
   dependsOn: ["run_salvo_remote"]

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -24,6 +24,9 @@ function set_salvo_asg_capacity() {
     --auto-scaling-group-name "${SALVO_REMOTE_ASG}" \
     --min-size "${desired_capacity}" \
     --desired-capacity "${desired_capacity}"
+
+  # Give the VM enough time to start up and register with AZP.
+  sleep 150
 }
 
 # Configure the salvo-remote ASG to have at least one instance to process jobs.

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -20,9 +20,10 @@ function set_salvo_asg_capacity() {
 	local desired_capacity="$1"
 
   aws autoscaling update-auto-scaling-group \
-    --auto-scaling-group-name ${SALVO_REMOTE_ASG} \
-    --min-size ${desired_capacity} \
-    --desired-capacity ${desired_capacity}
+    --region "${AWS_REGION}" \
+    --auto-scaling-group-name "${SALVO_REMOTE_ASG}" \
+    --min-size "${desired_capacity}" \
+    --desired-capacity "${desired_capacity}"
 }
 
 # Configure the salvo-remote ASG to have at least one instance to process jobs.

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -32,7 +32,7 @@ function preheat_salvo_asg() {
   set_salvo_asg_capacity 1
 
   # Give the VM enough time to start up and register with AZP.
-  local sleep_time=120
+  local sleep_time=1
   echo "Sleeping for ${sleep_time} seconds to give the ASG time to setup a VM."
   sleep ${sleep_time}
 }

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -24,15 +24,17 @@ function set_salvo_asg_capacity() {
     --auto-scaling-group-name "${SALVO_REMOTE_ASG}" \
     --min-size "${desired_capacity}" \
     --desired-capacity "${desired_capacity}"
-
-  # Give the VM enough time to start up and register with AZP.
-  sleep 150
 }
 
 # Configure the salvo-remote ASG to have at least one instance to process jobs.
 function preheat_salvo_asg() {
   echo "Preheating the salvo-remote ASG."
   set_salvo_asg_capacity 1
+
+  # Give the VM enough time to start up and register with AZP.
+  local sleep_time=150
+  echo "Sleeping for ${sleep_time} seconds to give the ASG time to setup a VM."
+  sleep ${sleep_time}
 }
 
 # Configure the salvo-remote ASG to have zero instance.

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -32,7 +32,7 @@ function preheat_salvo_asg() {
   set_salvo_asg_capacity 1
 
   # Give the VM enough time to start up and register with AZP.
-  local sleep_time=150
+  local sleep_time=120
   echo "Sleeping for ${sleep_time} seconds to give the ASG time to setup a VM."
   sleep ${sleep_time}
 }

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -30,11 +30,6 @@ function set_salvo_asg_capacity() {
 function preheat_salvo_asg() {
   echo "Preheating the salvo-remote ASG."
   set_salvo_asg_capacity 1
-
-  # Give the VM enough time to start up and register with AZP.
-  local sleep_time=120
-  echo "Sleeping for ${sleep_time} seconds to give the ASG time to setup a VM."
-  sleep ${sleep_time}
 }
 
 # Configure the salvo-remote ASG to have zero instance.

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -10,6 +10,9 @@ export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
 # The name of the salvo-remote ASG (Auto Scaling Group) this script controls.
 export SALVO_REMOTE_ASG="salvo-azp-agent-vm-x64_salvo-control_pool"
 
+# The region Salvo resources run in.
+export AWS_REGION="us-west-1"
+
 # Sets the capacity of the salvo-remote ASG.
 # Arguments:
 #   An integer, the desired capacity.

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -32,7 +32,7 @@ function preheat_salvo_asg() {
   set_salvo_asg_capacity 1
 
   # Give the VM enough time to start up and register with AZP.
-  local sleep_time=1
+  local sleep_time=120
   echo "Sleeping for ${sleep_time} seconds to give the ASG time to setup a VM."
   sleep ${sleep_time}
 }

--- a/salvo-remote/azure-pipelines/scripts/asg_control.sh
+++ b/salvo-remote/azure-pipelines/scripts/asg_control.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+# Required tokens, see:
+# https://github.com/envoyproxy/envoy-perf/blob/main/salvo-remote/azure-pipelines/README.md
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+
+# The name of the salvo-remote ASG (Auto Scaling Group) this script controls.
+export SALVO_REMOTE_ASG="salvo-azp-agent-vm-x64_salvo-control_pool"
+
+# Sets the capacity of the salvo-remote ASG.
+# Arguments:
+#   An integer, the desired capacity.
+function set_salvo_asg_capacity() {
+	local desired_capacity="$1"
+
+  aws autoscaling update-auto-scaling-group \
+    --auto-scaling-group-name ${SALVO_REMOTE_ASG} \
+    --min-size ${desired_capacity} \
+    --desired-capacity ${desired_capacity}
+}
+
+# Configure the salvo-remote ASG to have at least one instance to process jobs.
+function preheat_salvo_asg() {
+  echo "Preheating the salvo-remote ASG."
+  set_salvo_asg_capacity 1
+}
+
+# Configure the salvo-remote ASG to have zero instance.
+function cooldown_salvo_asg() {
+  echo "Cooling the salvo-remote ASG."
+  set_salvo_asg_capacity 0
+}
+
+
+# Set the action to perform.
+# If no parameters are defined, print out the help text.
+action=${1:-}
+
+case "${action}" in
+  "preheat")
+    preheat_salvo_asg
+    ;;
+  "cooldown")
+    cooldown_salvo_asg
+    ;;
+  *)
+    echo "usage: asg_control.sh {action}, the action must be one of [preheat, cooldown]"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -8,10 +8,11 @@ import (
 	"os"
 )
 
-var buildID = flag.String("build_id", "", "The ID of the AZP build that produced components and binaries for this salvo-remote execution.")
+var buildID = flag.String("build_id", "", "The ID of the AZP build that produced components and binaries for this salvo-remote execution. Can be overridden by providing a different ID in -build_id_override.")
+var buildIDOverride = flag.String("build_id_override", "current", "If set to other value than 'current', this overrides the value set via -build_id".)
 
 func main() {
 	flag.Parse()
-	fmt.Printf("salvo-remote not implemented yet, executed with -build_id %q\n", *buildID)
+	fmt.Printf("salvo-remote not implemented yet, executed with -build_id %q and -build_id_override %q\n", *buildID, *buildIDOverride)
 	os.Exit(1)
 }

--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -1,9 +1,17 @@
+// salvo-remote instruments the execution of performance tests on a sandbox
+// running remotely on AWS.
 package main
 
-import "fmt"
-import "os"
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+var buildID = flag.String("build_id", "", "The ID of the AZP build that produced components and binaries for this salvo-remote execution.")
 
 func main() {
-	fmt.Println("salvo-remote not implemented yet")
+	flag.Parse()
+	fmt.Printf("salvo-remote not implemented yet, executed with -build_id %q\n", *buildID)
 	os.Exit(1)
 }

--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -9,7 +9,7 @@ import (
 )
 
 var buildID = flag.String("build_id", "", "The ID of the AZP build that produced components and binaries for this salvo-remote execution. Can be overridden by providing a different ID in -build_id_override.")
-var buildIDOverride = flag.String("build_id_override", "current", "If set to other value than 'current', this overrides the value set via -build_id.")
+var buildIDOverride = flag.String("build_id_override", "", "If set, it overrides the value set via -build_id.")
 
 func main() {
 	flag.Parse()

--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -9,7 +9,7 @@ import (
 )
 
 var buildID = flag.String("build_id", "", "The ID of the AZP build that produced components and binaries for this salvo-remote execution. Can be overridden by providing a different ID in -build_id_override.")
-var buildIDOverride = flag.String("build_id_override", "current", "If set to other value than 'current', this overrides the value set via -build_id".)
+var buildIDOverride = flag.String("build_id_override", "current", "If set to other value than 'current', this overrides the value set via -build_id.")
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
Done here:
- the pipeline builds `salvo-remote` and the sandbox definitions.
- the pipeline preheats the Salvo ASG (starts at least one agent VM).
- the pipeline executes `salvo-remote`, passing in the build ID.
- allow for build ID overrides - this functionality saves time while debugging and will not be part of the API.
- `salvo-remote` now accepts two flags and prints them out to verify correct plumbing of the build ID.

Example execution: https://dev.azure.com/cncf/envoy/_build/results?buildId=137815&view=results