### PR TITLE
Objects and functions that describe sandbox instances.

### DIFF
--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -11,8 +11,8 @@ import (
 	"github.com/envoyproxy/envoy-perf/salvo-remote/sandboxes"
 )
 
-var buildID = flag.Int("build_id", 0, "The ID of the AZP build that produced components and binaries for this salvo-remote execution. Can be overridden by providing a different ID in -build_id_override.")
-var buildIDOverride = flag.Int("build_id_override", 0, "If set, it overrides the value set via -build_id.")
+var buildID = flag.Int64("build_id", 0, "The ID of the AZP build that produced components and binaries for this salvo-remote execution. Can be overridden by providing a different ID in -build_id_override.")
+var buildIDOverride = flag.Int64("build_id_override", 0, "If set, it overrides the value set via -build_id.")
 
 // validateFlags validates the provided flag values.
 func validateFlags() error {
@@ -26,7 +26,7 @@ func validateFlags() error {
 }
 
 // getBuildID determines what build ID should Salvo execute with.
-func getBuildID() int {
+func getBuildID() int64 {
 	if (*buildIDOverride) != 0 {
 		return *buildIDOverride
 	}

--- a/salvo-remote/salvo_remote_test.go
+++ b/salvo-remote/salvo_remote_test.go
@@ -33,8 +33,8 @@ func (fsm *fakeSandboxManager) Start(ctx context.Context, sbxs map[sandboxes.Typ
 func TestRunSalvoRemote(t *testing.T) {
 	tests := []struct {
 		desc            string
-		buildID         int
-		buildIDOverride int
+		buildID         int64
+		buildIDOverride int64
 		fakeSMStartErr  error
 		wantSbxs        map[sandboxes.Type]sandboxes.Instances
 		wantErrSubstr   string

--- a/salvo-remote/sandboxes/BUILD.bazel
+++ b/salvo-remote/sandboxes/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "sandboxes",
     srcs = [
+        "instances.go",
         "json.go",
         "sandboxes.go",
     ],
@@ -19,6 +20,7 @@ go_library(
 go_test(
     name = "sandboxes_test",
     srcs = [
+        "instances_test.go",
         "json_test.go",
         "sandboxes_test.go",
     ],

--- a/salvo-remote/sandboxes/instances.go
+++ b/salvo-remote/sandboxes/instances.go
@@ -1,0 +1,147 @@
+// instances.go defined data types that described deployed sandbox instances.
+package sandboxes
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+// Instance describes a single sandbox instance.
+type Instance struct {
+	// Type identifies the type of the sandbox instance.
+	Type Type
+
+	// LoadGenerators are the load generator VMs deployed in the sandbox.
+	LoadGenerators []*VM
+
+	// SUTs are the system under test VMs deployed in the sandbox.
+	SUTs []*VM
+
+	// Backends are the backend VMs deployed in the sandbox.
+	Backends []*VM
+}
+
+// newInstanceWithSingleVM creates an instance of the specified type with a single VM instance of each kind.
+func newInstanceWithSingleVM(typ Type) *Instance {
+	return &Instance{
+		Type:           typ,
+		LoadGenerators: []*VM{{}},
+		SUTs:           []*VM{{}},
+		Backends:       []*VM{{}},
+	}
+}
+
+// String implements fmt.Stringer.
+func (i *Instance) String() string {
+	b, err := json.Marshal(i)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// VM describes a VM deployed in a sandbox.
+type VM struct {
+	// IP is the primary private IP address of the VM.
+	// This is the IP address on the interface that either originates or receives load.
+	IP net.IP
+
+	// ControlIP is a private IP address that can be used by the control VM when accessing the VM.
+	// Note, the control VM is the VM that runs salvo-remote (this code).
+	ControlIP net.IP
+}
+
+const (
+	// Names of Terraform outputs that provide the primary private IPs of the VMs in the sandbox.
+	// These are the IPs that originate and receive load.
+	defSbxX64Gen0ControlIPs = "default_sandbox_x64_build_ids_to_load_generator_0_control_vm_subnet_ip_list"
+	defSbxX64Sut0ControlIPs = "default_sandbox_x64_build_ids_to_sut_0_control_vm_subnet_ip_list"
+	defSbxX64Bac0ControlIPs = "default_sandbox_x64_build_ids_to_backend_0_control_vm_subnet_ip_list"
+
+	// Names of Terraform outputs that provide the private IPs that can be used to control the VMs.
+	defSbxX64Gen0IPs = "default_sandbox_x64_build_ids_to_load_generator_0_load_generator_subnet_ip_list"
+	defSbxX64Sut0IPs = "default_sandbox_x64_build_ids_to_sut_0_load_generator_subnet_ip_list"
+	defSbxX64Bac0IPs = "default_sandbox_x64_build_ids_to_backend_0_backend_subnet_ip_list"
+)
+
+// parseInstances takes a Terraform output and parses it to identify sandbox instances.
+// The returned value maps sandbox build IDs to the sandbox instance.
+func parseInstances(sbxs map[Type]Instances, output map[string]tfexec.OutputMeta) (map[int64]*Instance, error) {
+	if len(sbxs) == 0 {
+		return nil, errors.New("at least one sandbox type has to be specified")
+	}
+
+	res := map[int64]*Instance{}
+	for typ, insts := range sbxs {
+		if len(insts) == 0 {
+			return nil, fmt.Errorf("no instances specified for sandbox type %s(%d), at least one instance must be specified", typ, typ)
+		}
+
+		switch typ {
+		case TypeDefaultSandboxX64:
+			instRes, err := parseDefaultSandboxX64(insts, output)
+			if err != nil {
+				return nil, err
+			}
+			combineInst(res, instRes)
+		default:
+			return nil, fmt.Errorf("unsupported sandbox type %s(%d)", typ, typ)
+		}
+	}
+
+	return res, nil
+}
+
+// combineInst combines instance b into instance a.
+func combineInst(a, b map[int64]*Instance) {
+	for k, v := range b {
+		a[k] = v
+	}
+}
+
+// parseDefaultSandboxX64 parses the Terraform outputs for a sendbox of type TypeDefaultSandboxX64.
+func parseDefaultSandboxX64(insts Instances, output map[string]tfexec.OutputMeta) (map[int64]*Instance, error) {
+	res := map[int64]*Instance{}
+	for _, instNum := range insts {
+		inst := newInstanceWithSingleVM(TypeDefaultSandboxX64)
+		res[instNum] = inst
+
+		for _, data := range []struct {
+			tfVar     string
+			instField *net.IP
+		}{
+			{defSbxX64Gen0ControlIPs, &inst.LoadGenerators[0].ControlIP},
+			{defSbxX64Sut0ControlIPs, &inst.SUTs[0].ControlIP},
+			{defSbxX64Bac0ControlIPs, &inst.Backends[0].ControlIP},
+			{defSbxX64Gen0IPs, &inst.LoadGenerators[0].IP},
+			{defSbxX64Sut0IPs, &inst.SUTs[0].IP},
+			{defSbxX64Bac0IPs, &inst.Backends[0].IP},
+		} {
+			outMeta, ok := output[data.tfVar]
+			if !ok {
+				return nil, fmt.Errorf("Terraform output doesn't contain variable %q", data.tfVar)
+			}
+
+			idIPs, err := unmarshalBuildIPMap(outMeta.Value)
+			if err != nil {
+				return nil, fmt.Errorf("unmarshalBuildIPMap for variable %q: %v, raw json: %q", data.tfVar, err, outMeta.Value)
+			}
+
+			ips, ok := idIPs[instNum]
+			if !ok {
+				return nil, fmt.Errorf("Terraform output doesn't contain sandbox instance %d in variable %q, got idIPs: %+v", instNum, data.tfVar, idIPs)
+			}
+
+			if got, want := len(ips), 1; got != want {
+				return nil, fmt.Errorf("Terraform returned invalid number(%d) of IPs in sandbox instance %d, variable %q, wanted %d, got ips: %+v", got, instNum, data.tfVar, want, ips)
+			}
+			*data.instField = ips[0]
+		}
+	}
+	return res, nil
+}

--- a/salvo-remote/sandboxes/instances_test.go
+++ b/salvo-remote/sandboxes/instances_test.go
@@ -1,0 +1,675 @@
+package sandboxes
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-exec/tfexec"
+)
+
+func TestParseInstances(t *testing.T) {
+	tests := []struct {
+		desc    string
+		sbxs    map[Type]Instances
+		output  map[string]tfexec.OutputMeta
+		want    map[int64]*Instance
+		wantErr bool
+	}{
+		{
+			desc: "unsupported sandbox type",
+			sbxs: map[Type]Instances{
+				Type(-1): {},
+			},
+			wantErr: true,
+		},
+		{
+			desc:    "no sandbox types provided",
+			sbxs:    map[Type]Instances{},
+			wantErr: true,
+		},
+		{
+			desc: "no instances provided",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "sbxs specifies instance not found in outputs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345, 67890},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["1.1.1.1"],
+					}
+`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["2.2.2.1"],
+					}
+`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["3.3.3.1"],
+					}
+`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["10.1.1.1"],
+					}
+`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["20.2.2.1"],
+					}
+`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["30.3.3.1"],
+					}
+`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0ControlIPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Sut0ControlIPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0ControlIPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0IPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Sut0IPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0IPs is missing",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0ControlIPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0ControlIPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0ControlIPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0IPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Sut0IPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0IPs has multiple IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1", "2.2.2.2"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0ControlIPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Sut0ControlIPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0ControlIPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Gen0IPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Sut0IPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "defSbxX64Bac0IPs has no IPs",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`"12345": ["1.1.1.1"]`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`"12345": []`),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "parses multiple instances",
+			sbxs: map[Type]Instances{
+				TypeDefaultSandboxX64: {12345, 67890},
+			},
+			output: map[string]tfexec.OutputMeta{
+				defSbxX64Gen0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["1.1.1.1"],
+						"67890": ["1.1.1.2"]
+					}
+`),
+				},
+				defSbxX64Sut0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["2.2.2.1"],
+						"67890": ["2.2.2.2"]
+					}
+`),
+				},
+				defSbxX64Bac0ControlIPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["3.3.3.1"],
+						"67890": ["3.3.3.2"]
+					}
+`),
+				},
+				defSbxX64Gen0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["10.1.1.1"],
+						"67890": ["10.1.1.2"]
+					}
+`),
+				},
+				defSbxX64Sut0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["20.2.2.1"],
+						"67890": ["20.2.2.2"]
+					}
+`),
+				},
+				defSbxX64Bac0IPs: {
+					Value: json.RawMessage(`
+					{
+						"12345": ["30.3.3.1"],
+						"67890": ["30.3.3.2"]
+					}
+`),
+				},
+			},
+			want: map[int64]*Instance{
+				12345: {
+					Type: TypeDefaultSandboxX64,
+					LoadGenerators: []*VM{
+						{
+							IP:        net.ParseIP("10.1.1.1"),
+							ControlIP: net.ParseIP("1.1.1.1"),
+						},
+					},
+					SUTs: []*VM{
+						{
+							IP:        net.ParseIP("20.2.2.1"),
+							ControlIP: net.ParseIP("2.2.2.1"),
+						},
+					},
+					Backends: []*VM{
+						{
+							IP:        net.ParseIP("30.3.3.1"),
+							ControlIP: net.ParseIP("3.3.3.1"),
+						},
+					},
+				},
+				67890: {
+					Type: TypeDefaultSandboxX64,
+					LoadGenerators: []*VM{
+						{
+							IP:        net.ParseIP("10.1.1.2"),
+							ControlIP: net.ParseIP("1.1.1.2"),
+						},
+					},
+					SUTs: []*VM{
+						{
+							IP:        net.ParseIP("20.2.2.2"),
+							ControlIP: net.ParseIP("2.2.2.2"),
+						},
+					},
+					Backends: []*VM{
+						{
+							IP:        net.ParseIP("30.3.3.2"),
+							ControlIP: net.ParseIP("3.3.3.2"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := parseInstances(tc.sbxs, tc.output)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseInstances => unexpected error: %v, wantErr: %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseInstances => unexpected diff (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/salvo-remote/sandboxes/sandboxes.go
+++ b/salvo-remote/sandboxes/sandboxes.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Instances represent sandbox instances, each integer is an AZP Build ID corresponding to AZP pipeline execution that built the components for the sandbox.
-type Instances []int
+type Instances []int64
 
 // terraformAPI abstracts calls to functions that interact with Terraform.
 // Exists to support dependency injection for unit testing.
@@ -152,7 +152,7 @@ func sbxsToTfVars(sbxs map[Type]Instances) ([]string, error) {
 		if len(instances) == 0 {
 			return nil, fmt.Errorf("requested sandboxes specified sandbox Type %v with zero instances, at least one instance (one build ID) must be specified", t)
 		}
-		seen := map[int]bool{}
+		seen := map[int64]bool{}
 		var instStrs []string
 		for _, inst := range instances {
 			if seen[inst] {
@@ -160,7 +160,7 @@ func sbxsToTfVars(sbxs map[Type]Instances) ([]string, error) {
 			}
 			seen[inst] = true
 
-			if min := 1; inst < min {
+			if min := int64(1); inst < min {
 				return nil, fmt.Errorf("requested sandboxes specified sandbox Type %v with instance (build ID) %d, the minimum allowed instance is %d", t, inst, min)
 			}
 			instStrs = append(instStrs, fmt.Sprintf("%d", inst))


### PR DESCRIPTION
- changed type of an instance id from `int` to `int64` since that is what we naturally unmarshal and convert from Terraform.