### PR TITLE
The Salvo controller now receives information about running sandbox instances.

### DIFF
--- a/salvo-remote/salvo_remote.go
+++ b/salvo-remote/salvo_remote.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/envoyproxy/envoy-perf/salvo-remote/sandboxes"
@@ -35,7 +36,7 @@ func getBuildID() int64 {
 
 // sandboxManager abstracts a type that manages sandbox instances.
 type sandboxManager interface {
-	Start(context.Context, map[sandboxes.Type]sandboxes.Instances) error
+	Start(context.Context, map[sandboxes.Type]sandboxes.Instances) (map[int64]*sandboxes.Instance, error)
 }
 
 // runSalvoRemote executes Salvo remotely and returns the exit code.
@@ -49,9 +50,12 @@ func runSalvoRemote(sm sandboxManager) error {
 	}
 	ctx := context.Background()
 
-	if err := sm.Start(ctx, sbxs); err != nil {
+	insts, err := sm.Start(ctx, sbxs)
+	if err != nil {
 		return fmt.Errorf("sm.Start => %v", err)
 	}
+
+	log.Printf("Terraform returned sandbox instances:\n%v", insts)
 	return nil
 }
 

--- a/salvo-remote/salvo_remote_test.go
+++ b/salvo-remote/salvo_remote_test.go
@@ -12,6 +12,8 @@ import (
 
 // fakeSandboxManager is a fake sandboxes.Manager implementation.
 type fakeSandboxManager struct {
+	// startOut is the output to return when Start is called.
+	startOut map[int64]*sandboxes.Instance
 	// startErr is the error to return when Start is called.
 	startErr error
 
@@ -19,15 +21,16 @@ type fakeSandboxManager struct {
 	sbxs map[sandboxes.Type]sandboxes.Instances
 }
 
-func newFakeSandboxManager(startErr error) *fakeSandboxManager {
+func newFakeSandboxManager(startOut map[int64]*sandboxes.Instance, startErr error) *fakeSandboxManager {
 	return &fakeSandboxManager{
+		startOut: startOut,
 		startErr: startErr,
 	}
 }
 
-func (fsm *fakeSandboxManager) Start(ctx context.Context, sbxs map[sandboxes.Type]sandboxes.Instances) error {
+func (fsm *fakeSandboxManager) Start(ctx context.Context, sbxs map[sandboxes.Type]sandboxes.Instances) (map[int64]*sandboxes.Instance, error) {
 	fsm.sbxs = sbxs
-	return fsm.startErr
+	return fsm.startOut, fsm.startErr
 }
 
 func TestRunSalvoRemote(t *testing.T) {
@@ -86,7 +89,7 @@ func TestRunSalvoRemote(t *testing.T) {
 			*buildID = tc.buildID
 			*buildIDOverride = tc.buildIDOverride
 
-			fsm := newFakeSandboxManager(tc.fakeSMStartErr)
+			fsm := newFakeSandboxManager(map[int64]*sandboxes.Instance{}, tc.fakeSMStartErr)
 			err := runSalvoRemote(fsm)
 			if (err != nil) != (tc.wantErrSubstr != "") {
 				t.Errorf("runSalvoRemote => unexpected error %v, wantErrSubstr: %q", err, tc.wantErrSubstr)

--- a/salvo-remote/sandboxes/sandboxes.go
+++ b/salvo-remote/sandboxes/sandboxes.go
@@ -54,6 +54,7 @@ type terraformAPI interface {
 // Exists to support dependency injection for unit testing.
 type terraform interface {
 	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
+	Output(ctx context.Context, opts ...tfexec.OutputOption) (map[string]tfexec.OutputMeta, error)
 }
 
 // tfexecTerraformAPI implements terraformAPI using the real tfexec library.
@@ -102,15 +103,16 @@ func NewManager(opts ...Option) *Manager {
 }
 
 // Start starts the specified sandbox instances.
-func (m *Manager) Start(ctx context.Context, sbxs map[Type]Instances) error {
+// Returns a map of sandbox build IDs to information about the sandbox instance.
+func (m *Manager) Start(ctx context.Context, sbxs map[Type]Instances) (map[int64]*Instance, error) {
 	tf, err := m.tAPI.initTf(ctx, sandboxDefDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	vars, err := sbxsToTfVars(sbxs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var opts []tfexec.ApplyOption
 	for _, v := range vars {
@@ -119,9 +121,19 @@ func (m *Manager) Start(ctx context.Context, sbxs map[Type]Instances) error {
 
 	log.Printf("Starting Salvo sbxs %+v.", sbxs)
 	if err := tf.Apply(ctx, opts...); err != nil {
-		return fmt.Errorf("tf.Apply => %v", err)
+		return nil, fmt.Errorf("tf.Apply => %v", err)
 	}
-	return nil
+
+	out, err := tf.Output(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tf.Output => %v", err)
+	}
+
+	res, err := parseInstances(sbxs, out)
+	if err != nil {
+		return nil, fmt.Errorf("parseInstances => %v", err)
+	}
+	return res, nil
 }
 
 // StopAll stops all sandbox instances.


### PR DESCRIPTION
- Package sandboxes returns sandbox instances.
- Binary salvo-remote prints out sandbox instances.