### PR TITLE
chore(bazel/salvo-remote): add MODULE.bazel files for bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/.vscode/*
 **/__pycache__/*
 bazel-*
+MODULE.bazel.lock
 **/venv/*
 **/.pytype/*
 # Local .terraform directories and files.

--- a/salvo-remote/MODULE.bazel
+++ b/salvo-remote/MODULE.bazel
@@ -1,0 +1,23 @@
+module(
+    name = "salvo-remote",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "gazelle", version = "0.30.0", dev_dependency = True, repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.39.1", dev_dependency = True, repo_name = "io_bazel_rules_go")
+
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+# -- bazel_dep definitions -- #
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.19.3")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+use_repo(
+    go_deps,
+    "com_github_google_go_cmp",
+    "com_github_hashicorp_go_version",
+    "com_github_hashicorp_hc_install",
+    "com_github_hashicorp_terraform_exec",
+)


### PR DESCRIPTION
The WORKSPACE system is going to be replaced by bzlmod. I followed https://bazel.build/external/migration to use the way to handle external dependencies.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
